### PR TITLE
Self aware

### DIFF
--- a/less/modal.less
+++ b/less/modal.less
@@ -6,6 +6,9 @@
     position: fixed;
     background-color: rgba(0,0,0,0.5);
     z-index: 999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
 
        -webkit-animation: fadein 2s; /* Safari, Chrome and Opera > 12.1 */
@@ -20,17 +23,10 @@
 
 
     .im-modal-content {
+        flex: 0 0 auto;
         animation: slidein 150ms;
-        position: absolute;
-        border: 1px solid white;
-        top: 30%;
-        right: 50%;
-        transform: translate(-50%, -50%);
-        background-color: white;
-        padding: 10px;
-        -webkit-box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
-        -moz-box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
-        box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
+
+
     }
 }
 
@@ -42,7 +38,7 @@
 }
 
 @keyframes slidein {
-    from { top: 0%; }
-    to   { top: 30%; }
+    from { transform: translate(0%, -50%); }
+    to   { transform: translate(0%, 0%); }
 }
 

--- a/less/modal.less
+++ b/less/modal.less
@@ -1,0 +1,48 @@
+.im-modal {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    position: fixed;
+    background-color: rgba(0,0,0,0.5);
+    z-index: 999;
+
+
+       -webkit-animation: fadein 2s; /* Safari, Chrome and Opera > 12.1 */
+       -moz-animation: fadein 2s; /* Firefox < 16 */
+        -ms-animation: fadein 2s; /* Internet Explorer */
+         -o-animation: fadein 2s; /* Opera < 12.1 */
+            animation: fadein 150ms;
+
+            animation-timing-function: ease-out;
+            animation-fill-mode: backwards;
+
+
+
+    .im-modal-content {
+        animation: slidein 150ms;
+        position: absolute;
+        border: 1px solid white;
+        top: 30%;
+        right: 50%;
+        transform: translate(-50%, -50%);
+        background-color: white;
+        padding: 10px;
+        -webkit-box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
+        -moz-box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
+        box-shadow: 2px 1px 5px -2px rgba(0,0,0,0.36);
+    }
+}
+
+
+
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes slidein {
+    from { top: 0%; }
+    to   { top: 30%; }
+}
+

--- a/less/site.less
+++ b/less/site.less
@@ -1,6 +1,6 @@
 @import "overrides";
 @import "tooltip";
-
+@import "modal";
 
 .force-wrap {
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intermine/im-tables "0.3.4"
+(defproject intermine/im-tables "0.4.0"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intermine/im-tables "0.4.0"
+(defproject org.intermine/im-tables "0.4.0"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/src/im_tables/components/bootstrap.cljs
+++ b/src/im_tables/components/bootstrap.cljs
@@ -1,5 +1,6 @@
 (ns im-tables.components.bootstrap
   (:require [reagent.core :as reagent]
+            [reagent.dom.server :as server]
             [oops.core :refer [ocall oapply oget oset!]]))
 
 
@@ -40,7 +41,7 @@
        [element (-> attributes
                     (assoc :data-html true)
                     (assoc :data-container "body")
-                    (update :data-content reagent/render-to-static-markup)) rest])}))
+                    (update :data-content server/render-to-static-markup)) rest])}))
 
 
 (defn inner-tooltip []
@@ -105,6 +106,7 @@
 
 (defn modal []
   (fn [{:keys [header body footer]}]
+    (js/console.log "FOOTER" footer)
     [:div#testModal.modal.fade {:role "dialog"}
      [:div.modal-dialog
       [:div.modal-content

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -21,7 +21,7 @@
                   (.getElementById js/document "app")))
 
 (defn ^:export init []
-  (re-frame/dispatch-sync [:initialize-db
+  #_(re-frame/dispatch-sync [:initialize-db
                            [:test :location]
                            {
                             :service {:root "www.flymine.org/query"}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -48,40 +48,42 @@
                  :where [{:path "Gene", :op "IN", :value "esyN demo list"}]})
 
 (def default-db
-  {
+  {:test {:location {
 
-   ;:service  {:root "www.flymine.org/query"}
-   ;:query    {:from   "Gene"
-   ;           :size   10
-   ;           :select ["secondaryIdentifier"
-   ;                    "symbol"
-   ;                    "primaryIdentifier"
-   ;                    "organism.name"
-   ;                    "homologues.homologue.symbol"]
-   ;           :where  [{:path  "Gene"
-   ;                     :op    "IN"
-   ;                     :value "esyN demo list"}
-   ;                    {:path  "Gene.symbol"
-   ;                     :op    "="
-   ;                     :value "*a*"
-   ;                     :code  "B"}]}
+                     ;:service  {:root "www.flymine.org/query"}
+                     ;:query    {:from   "Gene"
+                     ;           :size   10
+                     ;           :select ["secondaryIdentifier"
+                     ;                    "symbol"
+                     ;                    "primaryIdentifier"
+                     ;                    "organism.name"
+                     ;                    "homologues.homologue.symbol"]
+                     ;           :where  [{:path  "Gene"
+                     ;                     :op    "IN"
+                     ;                     :value "esyN demo list"}
+                     ;                    {:path  "Gene.symbol"
+                     ;                     :op    "="
+                     ;                     :value "*a*"
+                     ;                     :code  "B"}]}
 
-   :settings {:buffer 2
-              :pagination {:start 0
-                           :limit 20}
-              :data-out {:selected-format :tsv
-                         :accepted-formats {:tsv :all
-                                            :csv :all
-                                            :fasta [:Gene :Protein]}}
-              :links {:vocab {:mine "flymine"}
-                      :on-click nil
-                      :url (fn [vocab] (str "#/reportpage/"
-                                            (:mine vocab) "/"
-                                            (:class vocab) "/"
-                                            (:objectId vocab)))}}
-   :cache {:summaries {}
-           :summary {}
-           :selection {}
-           :overlay? false
-           :filters {}
-           :tree-view {:selection #{}}}})
+                     :service {:model "TESTMODEL"}
+
+                     :settings {:buffer 2
+                                :pagination {:start 0
+                                             :limit 20}
+                                :data-out {:selected-format :tsv
+                                           :accepted-formats {:tsv :all
+                                                              :csv :all
+                                                              :fasta [:Gene :Protein]}}
+                                :links {:vocab {:mine "flymine"}
+                                        :on-click nil
+                                        :url (fn [vocab] (str "#/reportpage/"
+                                                              (:mine vocab) "/"
+                                                              (:class vocab) "/"
+                                                              (:objectId vocab)))}}
+                     :cache {:summaries {}
+                             :summary {}
+                             :selection {}
+                             :overlay? false
+                             :filters {}
+                             :tree-view {:selection #{}}}}}})

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -48,42 +48,42 @@
                  :where [{:path "Gene", :op "IN", :value "esyN demo list"}]})
 
 (def default-db
-  {:test {:location {
+  {
 
-                     ;:service  {:root "www.flymine.org/query"}
-                     ;:query    {:from   "Gene"
-                     ;           :size   10
-                     ;           :select ["secondaryIdentifier"
-                     ;                    "symbol"
-                     ;                    "primaryIdentifier"
-                     ;                    "organism.name"
-                     ;                    "homologues.homologue.symbol"]
-                     ;           :where  [{:path  "Gene"
-                     ;                     :op    "IN"
-                     ;                     :value "esyN demo list"}
-                     ;                    {:path  "Gene.symbol"
-                     ;                     :op    "="
-                     ;                     :value "*a*"
-                     ;                     :code  "B"}]}
+   ;:service  {:root "www.flymine.org/query"}
+   ;:query    {:from   "Gene"
+   ;           :size   10
+   ;           :select ["secondaryIdentifier"
+   ;                    "symbol"
+   ;                    "primaryIdentifier"
+   ;                    "organism.name"
+   ;                    "homologues.homologue.symbol"]
+   ;           :where  [{:path  "Gene"
+   ;                     :op    "IN"
+   ;                     :value "esyN demo list"}
+   ;                    {:path  "Gene.symbol"
+   ;                     :op    "="
+   ;                     :value "*a*"
+   ;                     :code  "B"}]}
 
-                     :service {:model "TESTMODEL"}
+   ;:service {:model "TESTMODEL"}
 
-                     :settings {:buffer 2
-                                :pagination {:start 0
-                                             :limit 20}
-                                :data-out {:selected-format :tsv
-                                           :accepted-formats {:tsv :all
-                                                              :csv :all
-                                                              :fasta [:Gene :Protein]}}
-                                :links {:vocab {:mine "flymine"}
-                                        :on-click nil
-                                        :url (fn [vocab] (str "#/reportpage/"
-                                                              (:mine vocab) "/"
-                                                              (:class vocab) "/"
-                                                              (:objectId vocab)))}}
-                     :cache {:summaries {}
-                             :summary {}
-                             :selection {}
-                             :overlay? false
-                             :filters {}
-                             :tree-view {:selection #{}}}}}})
+   :settings {:buffer 2
+              :pagination {:start 0
+                           :limit 20}
+              :data-out {:selected-format :tsv
+                         :accepted-formats {:tsv :all
+                                            :csv :all
+                                            :fasta [:Gene :Protein]}}
+              :links {:vocab {:mine "flymine"}
+                      :on-click nil
+                      :url (fn [vocab] (str "#/reportpage/"
+                                            (:mine vocab) "/"
+                                            (:class vocab) "/"
+                                            (:objectId vocab)))}}
+   :cache {:summaries {}
+           :summary {}
+           :selection {}
+           :overlay? false
+           :filters {}
+           :tree-view {:selection #{}}}})

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -49,7 +49,7 @@
   (fn [{db :db} [_ loc name query options]]
     {:db db
      :im-tables/im-operation {:on-success [:imt.io/save-list-success]
-                              :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins ) options)}}))
+                              :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins) options)}}))
 
 (reg-event-fx
   :prep-modal
@@ -63,7 +63,7 @@
   (fn [{db :db} [_ loc]]
     (let [modal (ocall js/document :getElementById "testModal")]
       ;;feigning a click is easier than dismissing it programatically for some reason
-    (ocall modal "click"))
+      (ocall modal "click"))
     {:db (assoc-in db [:cache :modal] nil)}))
 
 (reg-event-db
@@ -249,6 +249,7 @@
 (defn move-nth
   "Shift an item from one index in a collection to another "
   [coll from-idx to-idx]
+  (js/console.log "WE" coll from-idx to-idx)
   (insert-nth (drop-nth from-idx coll) to-idx (nth coll from-idx)))
 
 (defn index
@@ -267,6 +268,7 @@
   (sandbox)
   (fn [db [_ loc view]]
     (let [outer-join? (some? (some #{view} (get-in db [:query :joins])))]
+      (js/console.log "DR" outer-join? loc view)
       (if outer-join?
         ; If the column (view) being dragged is part of an outer join then get the idx of the first occurance
         (assoc-in db [:cache :dragging-item] (index (partial begins-with? view) (get-in db [:query :select])))
@@ -348,9 +350,9 @@
   :main/sort-by
   (sandbox)
   (fn [{db :db} [_ loc view]]
-    (let [view              (join "." (drop 1 (split view ".")))
+    (let [view (join "." (drop 1 (split view ".")))
           [current-sort-by] (get-in db [:query :orderBy])
-          update?           (= view (:path current-sort-by))
+          update? (= view (:path current-sort-by))
           current-direction (get-in db [:query :orderBy 0 :direction])]
       {:db (if update?
              (update-in db [:query :orderBy 0]
@@ -413,7 +415,7 @@
   (fn [{db :db} [_ loc {:keys [start size]} results]]
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
           updated-results (assoc results :results new-results-map)]
-      {:db (assoc db :query-response updated-results)
+      {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
        :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
                          (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
@@ -423,8 +425,8 @@
   (sandbox)
   (fn [{db :db} [_ loc {:keys [start size]} results]]
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-          updated-results (assoc results :results (merge (get-in db [:query-response :results]) new-results-map))]
-      {:db (assoc db :query-response updated-results)
+          updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
+      {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
        :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
                          (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
@@ -433,7 +435,6 @@
   :im-tables.main/run-query
   (sandbox)
   (fn [{db :db} [_ loc merge?]]
-    (.debug js/console "Running query" (get db :query))
     (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
       {:db (assoc-in db [:cache :column-summary] {})
        ;:undo                   "Undo ran query"

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -420,20 +420,20 @@
   :main/replace-query-response
   (sandbox)
   (fn [{db :db} [_ loc {:keys [start size]} results]]
-    (println "no effect replace")
+    ;(println "no effect replace")
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
           updated-results (assoc results :results new-results-map)]
       {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
-       ;:dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-       ;                  (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
+       :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
+                         (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
        })))
 
 (reg-event-fx
   :main/merge-query-response
   (sandbox)
   (fn [{db :db} [_ loc {:keys [start size]} results]]
-    (println "no effect merge")
+    ;(println "no effect merge")
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
           updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
       {:db (assoc db :response updated-results)
@@ -447,7 +447,7 @@
   (sandbox)
   (fn [{db :db} [_ loc merge?]]
     (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
-      (js/console.log "Running query: " loc (get db :query))
+      ;(js/console.log "Running query: " loc (get db :query))
       {:db (assoc-in db [:cache :column-summary] {})
        ;:undo                   "Undo ran query"
        :dispatch-n [^:flush-dom [:show-overlay loc]

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -413,36 +413,41 @@
   :main/replace-query-response
   (sandbox)
   (fn [{db :db} [_ loc {:keys [start size]} results]]
+    (println "no effect replace")
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
           updated-results (assoc results :results new-results-map)]
       {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
-       :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-                         (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
+       ;:dispatch-n (into [^:flush-dom [:hide-overlay loc]]
+       ;                  (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
+       })))
 
 (reg-event-fx
   :main/merge-query-response
   (sandbox)
   (fn [{db :db} [_ loc {:keys [start size]} results]]
+    (println "no effect merge")
     (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
           updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
       {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
-       :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-                         (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
+       ;:dispatch-n (into [^:flush-dom [:hide-overlay loc]]
+       ;                  (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
+       })))
 
 (reg-event-fx
   :im-tables.main/run-query
   (sandbox)
   (fn [{db :db} [_ loc merge?]]
     (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
+      (js/console.log "Running query: " loc (get db :query))
       {:db (assoc-in db [:cache :column-summary] {})
        ;:undo                   "Undo ran query"
        :dispatch-n [^:flush-dom [:show-overlay loc]
                     [:main/deconstruct loc]]
        :im-tables/im-operation {:on-success (if merge?
-                                              [:main/merge-query-response loc pagination]
-                                              [:main/replace-query-response loc pagination])
+                                              ^:flush-dom [:main/merge-query-response loc pagination]
+                                              ^:flush-dom [:main/replace-query-response loc pagination])
                                 :op (partial fetch/table-rows
                                              (get db :service)
                                              (get db :query)

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -181,6 +181,13 @@
               (if (= value "") nil value))))
 
 ;;;;; TREE VIEW
+
+(reg-event-db
+  :tree-view/clear-state
+  (sandbox)
+  (fn [db [_ loc path-vec]]
+    (update-in db [:cache] dissoc :tree-view)))
+
 (reg-event-db
   :tree-view/toggle-selection
   (sandbox)

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -22,6 +22,13 @@
                                 :imt.main/save-model]
                      :dispatch [:im-tables.main/run-query loc]}]})
 
+; TODO - WIP - If assets are missing when a component is mounted then
+; fetch them and/or run necessary queries
+(reg-event-fx :im-tables/sync
+              (sandbox)
+              (fn [{db :db} [_ loc {:keys [query service location]}]]
+                {:db db}))
+
 (reg-event-fx
   :initialize-db
   (fn [_ [_ loc initial-state]]

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -42,8 +42,9 @@
 ; fetch them and/or run necessary queries
 (reg-event-fx :im-tables/boot
               (sandbox)
-              (fn [{db :db} [_ loc {:keys [query service location response] :as args}]]
-                {:db (or db db/default-db)
+              (fn [{db :db} [_ loc {:keys [query service location response settings] :as args}]]
+                {:db (or db (assoc-in db/default-db [:settings :pagination :limit]
+                                      (or (get-in settings [:settings :pagination :limit]) 10)))
                  :im-tables/setup [loc (or db db/default-db) args]}))
 
 (reg-fx :im-tables/setup

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -43,7 +43,7 @@
  ;;the main action to download files. This gets called by the download modal button.
  (sandbox)
  (fn [{db :db} [_ loc]]
-   (let [query-results (get-in db [:query-response :results])
+   (let [query-results (get-in db [:response :results])
          file-type ((get-in db [:settings :data-out :selected-format]) xsv)
          query (get-in db [:query])]
      (if (= (:file-type file-type) "fasta")

--- a/src/im_tables/events/pagination.cljs
+++ b/src/im_tables/events/pagination.cljs
@@ -7,7 +7,7 @@
   (sandbox)
   (fn [{db :db} [_ loc]]
     (let [{:keys [start limit] :as p} (get-in db [:settings :pagination])
-          fetch-more? (not-every? (fn [n] (contains? (get-in db [:query-response :results]) n)) (range start (+ start limit)))]
+          fetch-more? (not-every? (fn [n] (contains? (get-in db [:response :results]) n)) (range start (+ start limit)))]
       (cond-> {:db db}
               fetch-more? (assoc :dispatch [:im-tables.main/run-query loc true])))))
 
@@ -36,6 +36,6 @@
   :imt.settings/update-pagination-fullinc
   (sandbox)
   (fn [{db :db} [_ loc]]
-    (let [total (get-in db [:query-response :iTotalRecords])]
+    (let [total (get-in db [:response :iTotalRecords])]
       {:db       (assoc-in db [:settings :pagination :start] (- total (mod total 10)))
        :dispatch [:imt.pagination/check-for-results loc]})))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -8,7 +8,7 @@
 (reg-sub
   :main/query-response
   (fn [db [_ prefix]]
-    (get-in db (glue prefix [:results]))))
+    (get-in db (glue prefix [:response]))))
 
 (reg-sub
   :main/query
@@ -130,7 +130,7 @@
 (reg-sub
   :query-response/views
   (fn [db [_ prefix]]
-    (get-in db (glue prefix [:results :views]))))
+    (get-in db (glue prefix [:response :views]))))
 
 (reg-sub
   :query/joins

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -2,13 +2,13 @@
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [re-frame.core :as re-frame :refer [reg-sub subscribe]]))
 
-(defn glue [path remainder-vec]z
+(defn glue [path remainder-vec]
   (reduce conj (or path []) remainder-vec))
 
 (reg-sub
   :main/query-response
   (fn [db [_ prefix]]
-    (get-in db (glue prefix [:query-response]))))
+    (get-in db (glue prefix [:results]))))
 
 (reg-sub
   :main/query
@@ -130,7 +130,7 @@
 (reg-sub
   :query-response/views
   (fn [db [_ prefix]]
-    (get-in db (glue prefix [:query-response :views]))))
+    (get-in db (glue prefix [:results :views]))))
 
 (reg-sub
   :query/joins

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -2,7 +2,7 @@
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [re-frame.core :as re-frame :refer [reg-sub subscribe]]))
 
-(defn glue [path remainder-vec]
+(defn glue [path remainder-vec]z
   (reduce conj (or path []) remainder-vec))
 
 (reg-sub

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -15,75 +15,20 @@
        [:button.btn.btn-warning "Modal"]
        [:button.btn.btn-default {:on-click (fn [] (swap! show? not))} "Toggle"]
        (when @show?
-         (into [:div] (map (fn [n]
-                             [main-view/main {:location [:test :location n]
-                                              :service {:root "beta.flymine.org/beta"}
-                                              :settings {:pagination {:limit 10}}
-                                              :query {:from "Gene"
-                                                      :select ["symbol"
-                                                               "secondaryIdentifier"
-                                                               "primaryIdentifier"
-                                                               "organism.name"
-                                                               "dataSets.name"]
-                                                      :where [{:path "Gene.symbol"
-                                                               :op "LIKE"
-                                                               :value "M*"}]}
-                                              #_#_:query {:from "Gene"
-                                                          :select ["symbol"
-                                                                   "secondaryIdentifier"
-                                                                   "primaryIdentifier"
-                                                                   "organism.name"
-                                                                   "publications.firstAuthor"
-                                                                   "dataSets.name"]
-                                                          :joins ["Gene.publications"]
-                                                          :size n
-                                                          :sortOrder [{:path "symbol"
-                                                                       :direction "ASC"}]
-                                                          :where [
-                                                                  {:path "secondaryIdentifier"
-                                                                   :op "="
-                                                                   :value "AC3.1*" ;AC3*
-                                                                   :code "A"}
-                                                                  ]}
-                                              }]
-
-                             ) (range 0 1)))
-         #_[:div.row
-            [:div.col-xs-6 [main-view/main {:location [:test :location]
-                                            :service {:root "beta.flymine.org/beta"}
-                                            ;:query {:from "Gene"
-                                            ;        :select ["Gene.symbol"]
-                                            ;        :where [{:path "Gene.symbol"
-                                            ;                 :op "LIKE"
-                                            ;                 :value "M*"}]}
-                                            :query {:from "Gene"
-                                                    :select ["symbol"
-                                                             "secondaryIdentifier"
-                                                             "primaryIdentifier"
-                                                             "organism.name"
-                                                             "publications.firstAuthor"
-                                                             "dataSets.name"]
-                                                    :joins ["Gene.publications"]
-                                                    :size 5
-                                                    :sortOrder [{:path "symbol"
-                                                                 :direction "ASC"}]
-                                                    :where [
-                                                            {:path "secondaryIdentifier"
-                                                             :op "="
-                                                             :value "AC3.1*" ;AC3*
-                                                             :code "A"}
-                                                            ]}
-                                            }]]
-            #_[:div.col-xs-6 [main-view/main {:location [:test :location2]
-                                              :service {:root "beta.flymine.org/beta"}
-                                              ;:query {:from "Gene"
-                                              ;        :select ["Gene.symbol"]
-                                              ;        :where [{:path "Gene.symbol"
-                                              ;                 :op "LIKE"
-                                              ;                 :value "M*"}]}
-                                              :query {:from "Gene"
-                                                      :select ["Gene.symbol"]
-                                                      :where [{:path "Gene.symbol"
-                                                               :op "="
-                                                               :value "AB*"}]}
-                                              }]]])])))
+         (into [:div]
+               ; Increase these range to produce N number of tables on the same page
+               ; (useful for stress testing)
+               (->> (range 0 30)
+                    (map (fn [n]
+                       [main-view/main {:location [:test :location n]
+                                        :service {:root "beta.flymine.org/beta"}
+                                        :settings {:pagination {:limit 10}}
+                                        :query {:from "Gene"
+                                                :select ["symbol"
+                                                         "secondaryIdentifier"
+                                                         "primaryIdentifier"
+                                                         "organism.name"
+                                                         "dataSets.name"]
+                                                :where [{:path "Gene.symbol"
+                                                         :op "LIKE"
+                                                         :value "M*"}]}}])))))])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -10,28 +10,43 @@
     (fn []
       [:div.container-fluid
        [:button.btn.btn-default {:on-click (fn [] (swap! show? not))} "Toggle"]
-       (when @show? [main-view/main {:location [:test :location]
-                         :service {:root "beta.flymine.org/beta"}
-                         ;:query {:from "Gene"
-                         ;        :select ["Gene.symbol"]
-                         ;        :where [{:path "Gene.symbol"
-                         ;                 :op "LIKE"
-                         ;                 :value "M*"}]}
-                         :query {:from "Gene"
-                                 :select ["symbol"
-                                          "secondaryIdentifier"
-                                          "primaryIdentifier"
-                                          "organism.name"
-                                          "publications.firstAuthor"
-                                          "dataSets.name"]
-                                 :joins ["Gene.publications"]
-                                 :size 10
-                                 :sortOrder [{:path "symbol"
-                                              :direction "ASC"}]
-                                 :where [
-                                         {:path "secondaryIdentifier"
-                                          :op "="
-                                          :value "AC3.1*" ;AC3*
-                                          :code "A"}
-                                         ]}
-                         }])])))
+       (when @show?
+         [:div.row
+          [:div.col-xs-6 [main-view/main {:location [:test :location]
+                                          :service {:root "beta.flymine.org/beta"}
+                                          ;:query {:from "Gene"
+                                          ;        :select ["Gene.symbol"]
+                                          ;        :where [{:path "Gene.symbol"
+                                          ;                 :op "LIKE"
+                                          ;                 :value "M*"}]}
+                                          :query {:from "Gene"
+                                                  :select ["symbol"
+                                                           "secondaryIdentifier"
+                                                           "primaryIdentifier"
+                                                           "organism.name"
+                                                           "publications.firstAuthor"
+                                                           "dataSets.name"]
+                                                  :joins ["Gene.publications"]
+                                                  :size 10
+                                                  :sortOrder [{:path "symbol"
+                                                               :direction "ASC"}]
+                                                  :where [
+                                                          {:path "secondaryIdentifier"
+                                                           :op "="
+                                                           :value "AC3.1*" ;AC3*
+                                                           :code "A"}
+                                                          ]}
+                                          }]]
+          [:div.col-xs-6 [main-view/main {:location [:test :location2]
+                                          :service {:root "beta.flymine.org/beta"}
+                                          ;:query {:from "Gene"
+                                          ;        :select ["Gene.symbol"]
+                                          ;        :where [{:path "Gene.symbol"
+                                          ;                 :op "LIKE"
+                                          ;                 :value "M*"}]}
+                                          :query {:from "Gene"
+                                                  :select ["Gene.symbol"]
+                                                  :where [{:path "Gene.symbol"
+                                                           :op "="
+                                                           :value "AB*"}]}
+                                          }]]])])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -4,12 +4,15 @@
             [reagent.core :as r]
             [reagent.dom.server :as server]))
 
+
+
 ; This function is used for testing purposes.
 ; Real use cases should call [im-tables.views.core/main {settings-map}]
 (defn main-panel []
   (let [show? (r/atom true)]
     (fn []
       [:div.container-fluid
+       [:button.btn.btn-warning "Modal"]
        [:button.btn.btn-default {:on-click (fn [] (swap! show? not))} "Toggle"]
        (when @show?
          (into [:div] (map (fn [n]
@@ -44,43 +47,43 @@
                                                                   ]}
                                               }]
 
-                             ) (range 1 32)))
+                             ) (range 0 1)))
          #_[:div.row
-          [:div.col-xs-6 [main-view/main {:location [:test :location]
-                                          :service {:root "beta.flymine.org/beta"}
-                                          ;:query {:from "Gene"
-                                          ;        :select ["Gene.symbol"]
-                                          ;        :where [{:path "Gene.symbol"
-                                          ;                 :op "LIKE"
-                                          ;                 :value "M*"}]}
-                                          :query {:from "Gene"
-                                                  :select ["symbol"
-                                                           "secondaryIdentifier"
-                                                           "primaryIdentifier"
-                                                           "organism.name"
-                                                           "publications.firstAuthor"
-                                                           "dataSets.name"]
-                                                  :joins ["Gene.publications"]
-                                                  :size 5
-                                                  :sortOrder [{:path "symbol"
-                                                               :direction "ASC"}]
-                                                  :where [
-                                                          {:path "secondaryIdentifier"
-                                                           :op "="
-                                                           :value "AC3.1*" ;AC3*
-                                                           :code "A"}
-                                                          ]}
-                                          }]]
-          #_[:div.col-xs-6 [main-view/main {:location [:test :location2]
-                                          :service {:root "beta.flymine.org/beta"}
-                                          ;:query {:from "Gene"
-                                          ;        :select ["Gene.symbol"]
-                                          ;        :where [{:path "Gene.symbol"
-                                          ;                 :op "LIKE"
-                                          ;                 :value "M*"}]}
-                                          :query {:from "Gene"
-                                                  :select ["Gene.symbol"]
-                                                  :where [{:path "Gene.symbol"
-                                                           :op "="
-                                                           :value "AB*"}]}
-                                          }]]])])))
+            [:div.col-xs-6 [main-view/main {:location [:test :location]
+                                            :service {:root "beta.flymine.org/beta"}
+                                            ;:query {:from "Gene"
+                                            ;        :select ["Gene.symbol"]
+                                            ;        :where [{:path "Gene.symbol"
+                                            ;                 :op "LIKE"
+                                            ;                 :value "M*"}]}
+                                            :query {:from "Gene"
+                                                    :select ["symbol"
+                                                             "secondaryIdentifier"
+                                                             "primaryIdentifier"
+                                                             "organism.name"
+                                                             "publications.firstAuthor"
+                                                             "dataSets.name"]
+                                                    :joins ["Gene.publications"]
+                                                    :size 5
+                                                    :sortOrder [{:path "symbol"
+                                                                 :direction "ASC"}]
+                                                    :where [
+                                                            {:path "secondaryIdentifier"
+                                                             :op "="
+                                                             :value "AC3.1*" ;AC3*
+                                                             :code "A"}
+                                                            ]}
+                                            }]]
+            #_[:div.col-xs-6 [main-view/main {:location [:test :location2]
+                                              :service {:root "beta.flymine.org/beta"}
+                                              ;:query {:from "Gene"
+                                              ;        :select ["Gene.symbol"]
+                                              ;        :where [{:path "Gene.symbol"
+                                              ;                 :op "LIKE"
+                                              ;                 :value "M*"}]}
+                                              :query {:from "Gene"
+                                                      :select ["Gene.symbol"]
+                                                      :where [{:path "Gene.symbol"
+                                                               :op "="
+                                                               :value "AB*"}]}
+                                              }]]])])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -17,7 +17,7 @@
          (into [:div]
                ; Increase these range to produce N number of tables on the same page
                ; (useful for stress testing)
-               (->> (range 0 1)
+               (->> (range 0 2)
                     (map (fn [n]
                        [main-view/main {:location [:test :location n]
                                         :service {:root "beta.flymine.org/beta"}

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -1,17 +1,37 @@
 (ns im-tables.views
   (:require [re-frame.core :as re-frame :refer [dispatch]]
-            [im-tables.views.core :as main-view]))
+            [im-tables.views.core :as main-view]
+            [reagent.core :as r]))
 
 ; This function is used for testing purposes.
 ; Real use cases should call [im-tables.views.core/main {settings-map}]
 (defn main-panel []
-  (fn []
-    [:div.container-fluid
-     [main-view/main {:location [:test :location]
-                      :service {:root "beta.flymine.org/beta"
-                                :model "m"}
-                      :query {:from "Gene"
-                              :select ["Gene.symbol"]
-                              :where [{:path "Gene.symbol"
-                                       :op "LIKE"
-                                       :value "M*"}]}}]]))
+  (let [show? (r/atom true)]
+    (fn []
+      [:div.container-fluid
+       [:button.btn.btn-default {:on-click (fn [] (swap! show? not))} "Toggle"]
+       (when @show? [main-view/main {:location [:test :location]
+                         :service {:root "beta.flymine.org/beta"}
+                         ;:query {:from "Gene"
+                         ;        :select ["Gene.symbol"]
+                         ;        :where [{:path "Gene.symbol"
+                         ;                 :op "LIKE"
+                         ;                 :value "M*"}]}
+                         :query {:from "Gene"
+                                 :select ["symbol"
+                                          "secondaryIdentifier"
+                                          "primaryIdentifier"
+                                          "organism.name"
+                                          "publications.firstAuthor"
+                                          "dataSets.name"]
+                                 :joins ["Gene.publications"]
+                                 :size 10
+                                 :sortOrder [{:path "symbol"
+                                              :direction "ASC"}]
+                                 :where [
+                                         {:path "secondaryIdentifier"
+                                          :op "="
+                                          :value "AC3.1*" ;AC3*
+                                          :code "A"}
+                                         ]}
+                         }])])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -1,8 +1,16 @@
 (ns im-tables.views
-    (:require [re-frame.core :as re-frame :refer [dispatch]]
-              [im-tables.views.core :as main-view]))
+  (:require [re-frame.core :as re-frame :refer [dispatch]]
+            [im-tables.views.core :as main-view]))
 
+; This function is used for testing purposes.
+; Real use cases should call [im-tables.views.core/main {settings-map}]
 (defn main-panel []
   (fn []
     [:div.container-fluid
-     [main-view/main [:test :location]]]))
+     [main-view/main {:location [:test :location]
+                      :service {:root "beta.flymine.org/beta"}
+                      :query {:from "Gene"
+                              :select ["Gene.symbol"]
+                              :where [{:path "Gene.symbol"
+                                       :op "LIKE"
+                                       :value "M*"}]}}]]))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -8,7 +8,8 @@
   (fn []
     [:div.container-fluid
      [main-view/main {:location [:test :location]
-                      :service {:root "beta.flymine.org/beta"}
+                      :service {:root "beta.flymine.org/beta"
+                                :model "m"}
                       :query {:from "Gene"
                               :select ["Gene.symbol"]
                               :where [{:path "Gene.symbol"

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -4,10 +4,9 @@
             [reagent.core :as r]
             [reagent.dom.server :as server]))
 
-
-
 ; This function is used for testing purposes.
-; Real use cases should call [im-tables.views.core/main {settings-map}]
+; When using im-tables in real life, you could call the view like so:
+; [im-tables.views.core/main {:location ... :service ... :query ...}]
 (defn main-panel []
   (let [show? (r/atom true)]
     (fn []
@@ -18,7 +17,7 @@
          (into [:div]
                ; Increase these range to produce N number of tables on the same page
                ; (useful for stress testing)
-               (->> (range 0 30)
+               (->> (range 0 1)
                     (map (fn [n]
                        [main-view/main {:location [:test :location n]
                                         :service {:root "beta.flymine.org/beta"}

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -1,7 +1,8 @@
 (ns im-tables.views
   (:require [re-frame.core :as re-frame :refer [dispatch]]
             [im-tables.views.core :as main-view]
-            [reagent.core :as r]))
+            [reagent.core :as r]
+            [reagent.dom.server :as server]))
 
 ; This function is used for testing purposes.
 ; Real use cases should call [im-tables.views.core/main {settings-map}]
@@ -11,7 +12,40 @@
       [:div.container-fluid
        [:button.btn.btn-default {:on-click (fn [] (swap! show? not))} "Toggle"]
        (when @show?
-         [:div.row
+         (into [:div] (map (fn [n]
+                             [main-view/main {:location [:test :location n]
+                                              :service {:root "beta.flymine.org/beta"}
+                                              :settings {:pagination {:limit 10}}
+                                              :query {:from "Gene"
+                                                      :select ["symbol"
+                                                               "secondaryIdentifier"
+                                                               "primaryIdentifier"
+                                                               "organism.name"
+                                                               "dataSets.name"]
+                                                      :where [{:path "Gene.symbol"
+                                                               :op "LIKE"
+                                                               :value "M*"}]}
+                                              #_#_:query {:from "Gene"
+                                                          :select ["symbol"
+                                                                   "secondaryIdentifier"
+                                                                   "primaryIdentifier"
+                                                                   "organism.name"
+                                                                   "publications.firstAuthor"
+                                                                   "dataSets.name"]
+                                                          :joins ["Gene.publications"]
+                                                          :size n
+                                                          :sortOrder [{:path "symbol"
+                                                                       :direction "ASC"}]
+                                                          :where [
+                                                                  {:path "secondaryIdentifier"
+                                                                   :op "="
+                                                                   :value "AC3.1*" ;AC3*
+                                                                   :code "A"}
+                                                                  ]}
+                                              }]
+
+                             ) (range 1 32)))
+         #_[:div.row
           [:div.col-xs-6 [main-view/main {:location [:test :location]
                                           :service {:root "beta.flymine.org/beta"}
                                           ;:query {:from "Gene"
@@ -27,7 +61,7 @@
                                                            "publications.firstAuthor"
                                                            "dataSets.name"]
                                                   :joins ["Gene.publications"]
-                                                  :size 10
+                                                  :size 5
                                                   :sortOrder [{:path "symbol"
                                                                :direction "ASC"}]
                                                   :where [
@@ -37,7 +71,7 @@
                                                            :code "A"}
                                                           ]}
                                           }]]
-          [:div.col-xs-6 [main-view/main {:location [:test :location2]
+          #_[:div.col-xs-6 [main-view/main {:location [:test :location2]
                                           :service {:root "beta.flymine.org/beta"}
                                           ;:query {:from "Gene"
                                           ;        :select ["Gene.symbol"]

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -33,15 +33,15 @@
         [:div.modal-footer footer]]]]]))
 
 #_(defn custom-modal []
-  (fn [loc {:keys [header body footer]}]
-    (js/console.log "content" )
-    [:div.im-modal
-     {:on-click (fn [e] (dispatch [:prep-modal loc nil]))}
-     [:div.im-modal-content
-      {:on-click (fn [e] (ocall e :stopPropagation))}
-      [:div.im-modal-header header]
-      [:div.im-modal-body body]
-      [:div.im-modal-footer footer]]]))
+    (fn [loc {:keys [header body footer]}]
+      (js/console.log "content")
+      [:div.im-modal
+       {:on-click (fn [e] (dispatch [:prep-modal loc nil]))}
+       [:div.im-modal-content
+        {:on-click (fn [e] (ocall e :stopPropagation))}
+        [:div.im-modal-header header]
+        [:div.im-modal-body body]
+        [:div.im-modal-footer footer]]]))
 
 (defn main [{:keys [location]} state]
   (let [response (subscribe [:main/query-response location])

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -4,7 +4,8 @@
             [im-tables.views.dashboard.main :as dashboard]
             [im-tables.views.table.core :as table]
             [im-tables.components.bootstrap :refer [modal]]
-            [reagent.dom.server :as server]))
+            [reagent.dom.server :as server]
+            [oops.core :refer [ocall]]))
 
 (def css-transition-group
   (reagent/adapt-react-class js/React.addons.CSSTransitionGroup))
@@ -19,7 +20,12 @@
        [:div.overlay
         [:i.fa.fa-cog.fa-spin.fa-4x.fa-fw]])]))
 
-
+(defn custom-modal []
+  (fn [loc content]
+    (js/console.log "C" (reagent/children (reagent/current-component)))
+    [:div.im-modal
+     {:on-click (fn [e] (ocall e :stopPropagation) (dispatch [:prep-modal loc nil]))}
+     [:div.im-modal-content content]]))
 
 (defn main [{:keys [location]} state]
   (let [response (subscribe [:main/query-response location])
@@ -41,6 +47,11 @@
            [:div.im-table.relative
             ; When the mouse touches the table, set the flag to render the actual React components
             {:on-mouse-over (fn [] (reset! static? false))}
+
+            (when @modal-markup
+              [custom-modal location @modal-markup]
+              ;[custom-modal location @modal-markup]
+              )
 
             (if @static?
               ; If static (optimised) then only show an HTML representations of the React components
@@ -71,5 +82,7 @@
 
 
             ; Use just one modal and change its contents dynamically
+            ;(js/console.log "MM" location @modal-markup)
             [modal @modal-markup]
+            [:pre (str @modal-markup)]
             ]))})))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -28,7 +28,8 @@
     (reagent/create-class
       {
        :component-will-mount (fn [this]
-                               (dispatch [:im-tables/sync location (reagent/props this)]))
+                               (dispatch [:im-tables/sync location (reagent/props this)])
+                               )
 
        :reagent-render
        (fn [{:keys [location query]}]

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -21,11 +21,27 @@
         [:i.fa.fa-cog.fa-spin.fa-4x.fa-fw]])]))
 
 (defn custom-modal []
-  (fn [loc content]
-    (js/console.log "C" (reagent/children (reagent/current-component)))
+  (fn [loc {:keys [header body footer]}]
     [:div.im-modal
-     {:on-click (fn [e] (ocall e :stopPropagation) (dispatch [:prep-modal loc nil]))}
-     [:div.im-modal-content content]]))
+     {:on-click (fn [e] (dispatch [:prep-modal loc nil]))}
+     [:div.im-modal-content
+      {:on-click (fn [e] (ocall e :stopPropagation))}
+      [:div.modal-dialog
+       [:div.modal-content
+        [:div.modal-header header]
+        [:div.modal-body body]
+        [:div.modal-footer footer]]]]]))
+
+#_(defn custom-modal []
+  (fn [loc {:keys [header body footer]}]
+    (js/console.log "content" )
+    [:div.im-modal
+     {:on-click (fn [e] (dispatch [:prep-modal loc nil]))}
+     [:div.im-modal-content
+      {:on-click (fn [e] (ocall e :stopPropagation))}
+      [:div.im-modal-header header]
+      [:div.im-modal-body body]
+      [:div.im-modal-footer footer]]]))
 
 (defn main [{:keys [location]} state]
   (let [response (subscribe [:main/query-response location])
@@ -83,6 +99,6 @@
 
             ; Use just one modal and change its contents dynamically
             ;(js/console.log "MM" location @modal-markup)
-            [modal @modal-markup]
+            ;[modal @modal-markup]
             [:pre (str @modal-markup)]
             ]))})))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -27,10 +27,7 @@
         modal-markup (subscribe [:modal location])]
     (reagent/create-class
       {
-       :component-will-mount (fn [this]
-                               (dispatch [:im-tables/sync location (reagent/props this)])
-                               )
-
+       :component-will-mount (fn [this] (dispatch [:im-tables/boot location (reagent/props this)]))
        :reagent-render
        (fn [{:keys [location query]}]
          [:div.im-table.relative

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -3,7 +3,8 @@
             [reagent.core :as reagent]
             [im-tables.views.dashboard.main :as dashboard]
             [im-tables.views.table.core :as table]
-            [im-tables.components.bootstrap :refer [modal]]))
+            [im-tables.components.bootstrap :refer [modal]]
+            [reagent.dom.server :as server]))
 
 (def css-transition-group
   (reagent/adapt-react-class js/React.addons.CSSTransitionGroup))
@@ -24,22 +25,51 @@
   (let [response (subscribe [:main/query-response location])
         pagination (subscribe [:settings/pagination location])
         overlay? (subscribe [:style/overlay? location])
-        modal-markup (subscribe [:modal location])]
+        modal-markup (subscribe [:modal location])
+        static? (reagent/atom true)]
     (reagent/create-class
       {
        :component-will-mount (fn [this] (dispatch [:im-tables/boot location (reagent/props this)]))
        :reagent-render
        (fn [{:keys [location query]}]
-         [:div.im-table.relative
-          ; Cover the app whenever it's thinking
-          [table-thinking @overlay?]
 
-          ;[:button.btn.btn-default {:on-click (fn [] (dispatch [:printdb]))} "Log DB"]
-          ; The dashboard above the table (controls
-          [dashboard/main location @response @pagination]
-          ; The actual table
+         ; The query results are stored in a map with the result index as the key.
+         ; In other words, we're not using a vector! To generate a speedy preview,
+         ; get the first n results to be shown as a simple table:
+         ; (get results 0), (get results 1), (get results 2) ... (get results limit)
+         (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
+           [:div.im-table.relative
+            ; When the mouse touches the table, set the flag to render the actual React components
+            {:on-mouse-over (fn [] (reset! static? false))}
 
-          ;[:div.ontop "t"]
-          [table/main location @response @pagination]
-          ; Use just one modal and change its contents dynamically
-          [modal @modal-markup]])})))
+            (if @static?
+              ; If static (optimised) then only show an HTML representations of the React components
+              [:div
+               ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
+               [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
+               [:table.table.table-condensed.table-bordered.table-striped
+                ; Good old static (fast) html table:
+                (into [:tbody] (map (fn [row]
+                                      (into [:tr] (map (fn [cell]
+                                                         [:td (:value cell)]) row))) preview-rows))]]
+              ; Otherwise show the interactive React components
+              [:div
+               [dashboard/main location @response @pagination]
+               [table/main location @response @pagination]])
+
+
+            ; Cover the app whenever it's thinking
+            ;[table-thinking @overlay?]
+
+            ;[:button.btn.btn-default {:on-click (fn [] (dispatch [:printdb]))} "Log DB"]
+            ; The dashboard above the table (controls
+
+            ; The actual table
+            ;[dashboard/main location @response @pagination]
+
+            ;[:div.ontop "t"]
+
+
+            ; Use just one modal and change its contents dynamically
+            [modal @modal-markup]
+            ]))})))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -11,7 +11,7 @@
 (defn table-thinking []
   (fn [show?]
     [css-transition-group
-     {:transition-name          "fade"
+     {:transition-name "fade"
       :transition-enter-timeout 50
       :transition-leave-timeout 50}
      (if show?
@@ -20,41 +20,28 @@
 
 
 
-(defn main [loc state]
-  (let [response     (subscribe [:main/query-response loc])
-        pagination   (subscribe [:settings/pagination loc])
-        overlay?     (subscribe [:style/overlay? loc])
-        modal-markup (subscribe [:modal loc])]
+(defn main [{:keys [location]} state]
+  (let [response (subscribe [:main/query-response location])
+        pagination (subscribe [:settings/pagination location])
+        overlay? (subscribe [:style/overlay? location])
+        modal-markup (subscribe [:modal location])]
     (reagent/create-class
       {
-       ;:component-will-mount
-       ;(fn [e]
-       ;  (if (and loc state)
-       ;    (dispatch [:im-tables.main/replace-all-state loc state])))
-       ;:component-will-update
-       ;(fn [this new-arg-v]
-       ;  (let [[_ l old-state] (reagent/argv this)
-       ;        [_ l new-state] new-arg-v]
-       ;    ;(.log js/console "O" (reagent/argv this))
-       ;    ;(.log js/console "N" new-arg-v)
-       ;    ;(.log js/console "old-state" old-state)
-       ;    ;(.log js/console "new-state" new-state)
-       ;    (if (not= old-state new-state)
-       ;      (do
-       ;        (.log js/console "UPDATING THIS" new-state)
-       ;        (dispatch [:im-tables.main/replace-all-state loc new-state])))))
+       :component-will-mount (fn [this]
+                               (dispatch [:im-tables/sync location (reagent/props this)]))
+
        :reagent-render
-       (fn [loc]
+       (fn [{:keys [location query]}]
          [:div.im-table.relative
           ; Cover the app whenever it's thinking
           [table-thinking @overlay?]
 
           ;[:button.btn.btn-default {:on-click (fn [] (dispatch [:printdb]))} "Log DB"]
           ; The dashboard above the table (controls
-          [dashboard/main loc @response @pagination]
+          [dashboard/main location @response @pagination]
           ; The actual table
 
           ;[:div.ontop "t"]
-          [table/main loc @response @pagination]
+          [table/main location @response @pagination]
           ; Use just one modal and change its contents dynamically
           [modal @modal-markup]])})))

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -61,7 +61,8 @@
     :on-click
     (fn [e]
       (dispatch [:prep-modal loc (export-menu loc)])
-      (dispatch [:prep-modal loc [:div [:h1 "Test"] [:p "thanks"]]])
+      ;(dispatch [:prep-modal loc [:div [:h1 {:on-click (fn [] (println "TEST"))} "Test"] [:p "thanks"]]])
+
       )}
    [:i.fa.fa-download] " Export"])
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -54,10 +54,14 @@
 
 (defn exporttable [loc]
   [:button.btn.btn-default
-   {:data-toggle "modal"
-    :data-target "#testModal"
+   {
+    ;:data-toggle "modal"
+    ;:data-target "#testModal"
     :type "button"
     :on-click
     (fn [e]
-      (dispatch [:prep-modal loc (export-menu loc)]))}
+      (dispatch [:prep-modal loc (export-menu loc)])
+      (dispatch [:prep-modal loc [:div [:h1 "Test"] [:p "thanks"]]])
+      )}
    [:i.fa.fa-download] " Export"])
+

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -20,7 +20,9 @@
 
         [:div.btn-group
          [:button.btn.btn-default
-          {:on-click (fn [] (dispatch [:prep-modal loc (saver/make-modal loc)]))}
+          {:on-click (fn []
+                       (dispatch [:tree-view/clear-state loc])
+                       (dispatch [:prep-modal loc (saver/make-modal loc)]))}
           [:i.fa.fa-columns] " Add Columns"]]
 
         #_[:div.btn-group

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -4,7 +4,9 @@
             [im-tables.views.dashboard.manager.relationships.main :as rel-manager]
             [im-tables.views.dashboard.undo :as undo]
             [im-tables.views.dashboard.save :as save]
+            [im-tables.views.dashboard.manager.columns.main :as saver]
             [im-tables.views.dashboard.exporttable :as exporttable]
+            [re-frame.core :refer [dispatch]]
             [oops.core :refer [ocall]]))
 
 (defn main []
@@ -15,7 +17,13 @@
      [:div.row.im-table-toolbar
       [:div.col-xs-6
        [:div.btn-toolbar
+
         [:div.btn-group
+         [:button.btn.btn-default
+          {:on-click (fn [] (dispatch [:prep-modal loc (saver/make-modal loc)]))}
+          [:i.fa.fa-columns] " Add Columns"]]
+
+        #_[:div.btn-group
          [:button.btn.btn-default
           {:data-toggle "modal"
            :data-target "#myModal"}

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -21,14 +21,9 @@
         [:div.btn-group
          [:button.btn.btn-default
           {:on-click (fn []
+                       ; Clear the previous state of the column manager when (re)opening
                        (dispatch [:tree-view/clear-state loc])
                        (dispatch [:prep-modal loc (saver/make-modal loc)]))}
-          [:i.fa.fa-columns] " Add Columns"]]
-
-        #_[:div.btn-group
-         [:button.btn.btn-default
-          {:data-toggle "modal"
-           :data-target "#myModal"}
           [:i.fa.fa-columns] " Add Columns"]]
         [:div.btn-group [rel-manager/main loc]]
         [:div.btn-group [save/main loc]]

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -9,13 +9,13 @@
 (defn tree-node []
   (let [expanded-map (reagent/atom {})]
     (fn [loc class details model current-path selected views]
-      (let [attributes  (get details :attributes)
+      (let [attributes (get details :attributes)
             collections (get details :collections)]
         [:ul.tree-view.list-unstyled.no-select
          (into [:ul.attributes.list-unstyled]
                (map (fn [{:keys [name type]}]
                       (let [original-view? (some? (some #{(conj current-path name)} views))
-                            selected?      (some? (some #{(conj current-path name)} selected))]
+                            selected? (some? (some #{(conj current-path name)} selected))]
 
                         [:li
                          {:on-click (fn [e]
@@ -46,58 +46,55 @@
 (defn tree-view []
   (fn [loc model query selected]
     (let [sterilized-query (query/sterilize-query query)
-          views            (into #{} (map (fn [v] (apply conj [] (clojure.string/split v "."))) (:select sterilized-query)))]
+          views (into #{} (map (fn [v] (apply conj [] (clojure.string/split v "."))) (:select sterilized-query)))]
       [:div
        [tree-node loc (keyword (:from query)) (get-in model [:classes (keyword (:from query))]) model [(:from query)] selected views]])))
 
 (defn my-modal []
   (fn [loc]
-    (let [model    (subscribe [:assets/model loc])
+    (let [model (subscribe [:assets/model loc])
           selected (subscribe [:tree-view/selection loc])
-          query    (subscribe [:main/query loc])]
+          query (subscribe [:main/query loc])]
 
       {:header []
        :body [:h1 "I am the body"]
        :footer []}
 
       #_[:div#myModal.modal.fade {:role "dialog"}
-       [:div.modal-dialog
-        [:div.modal-content
-         [:div.modal-header [:h3 "Add Columns"]]
-         [:div.modal-body
-          [tree-view loc @model @query @selected]]
-         [:div.modal-footer
-          [:div.btn-toolbar.pull-right
-           [:button.btn.btn-default
-            {:data-dismiss "modal"}
-            "Cancel"]
-           [:button.btn.btn-success
-            {:data-dismiss "modal"
-             :disabled (< (count @selected) 1)
-             :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
-            (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]]
+         [:div.modal-dialog
+          [:div.modal-content
+           [:div.modal-header [:h3 "Add Columns"]]
+           [:div.modal-body
+            [tree-view loc @model @query @selected]]
+           [:div.modal-footer
+            [:div.btn-toolbar.pull-right
+             [:button.btn.btn-default
+              {:data-dismiss "modal"}
+              "Cancel"]
+             [:button.btn.btn-success
+              {:data-dismiss "modal"
+               :disabled (< (count @selected) 1)
+               :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
+              (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]]
       )))
 
 (defn modal-body []
   (fn [loc]
-    (let [model    (subscribe [:assets/model loc])
+    (let [model (subscribe [:assets/model loc])
           selected (subscribe [:tree-view/selection loc])
-          query    (subscribe [:main/query loc])]
+          query (subscribe [:main/query loc])]
 
       [tree-view loc @model @query @selected]
       )))
 
 (defn modal-footer []
   (fn [loc]
-    (let [model    (subscribe [:assets/model loc])
+    (let [model (subscribe [:assets/model loc])
           selected (subscribe [:tree-view/selection loc])
-          query    (subscribe [:main/query loc])]
-
+          query (subscribe [:main/query loc])]
       [:div.btn-toolbar.pull-right
        [:button.btn.btn-default
-        {:on-click (fn []
-                     (dispatch [:prep-modal loc nil])
-                     (dispatch [:tree-view/clear-state loc]))}
+        {:on-click (fn [] (dispatch [:prep-modal loc nil]))}
         "Cancel"]
        [:button.btn.btn-success
         {:data-dismiss "modal"

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -55,7 +55,12 @@
     (let [model    (subscribe [:assets/model loc])
           selected (subscribe [:tree-view/selection loc])
           query    (subscribe [:main/query loc])]
-      [:div#myModal.modal.fade {:role "dialog"}
+
+      {:header []
+       :body [:h1 "I am the body"]
+       :footer []}
+
+      #_[:div#myModal.modal.fade {:role "dialog"}
        [:div.modal-dialog
         [:div.modal-content
          [:div.modal-header [:h3 "Add Columns"]]
@@ -70,7 +75,43 @@
             {:data-dismiss "modal"
              :disabled (< (count @selected) 1)
              :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
-            (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]])))
+            (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]]
+      )))
+
+(defn modal-body []
+  (fn [loc]
+    (let [model    (subscribe [:assets/model loc])
+          selected (subscribe [:tree-view/selection loc])
+          query    (subscribe [:main/query loc])]
+
+      [tree-view loc @model @query @selected]
+      )))
+
+(defn modal-footer []
+  (fn [loc]
+    (let [model    (subscribe [:assets/model loc])
+          selected (subscribe [:tree-view/selection loc])
+          query    (subscribe [:main/query loc])]
+
+      [:div.btn-toolbar.pull-right
+       [:button.btn.btn-default
+        {:on-click (fn []
+                     (dispatch [:prep-modal loc nil])
+                     (dispatch [:tree-view/clear-state loc]))}
+        "Cancel"]
+       [:button.btn.btn-success
+        {:data-dismiss "modal"
+         :disabled (< (count @selected) 1)
+         :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
+        (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]
+      )))
+
+(defn make-modal [loc]
+  {:header [:h3 "Add Columns"]
+   :body [modal-body loc]
+   :footer [modal-footer loc]})
+
+
 
 
 (defn main []

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -99,7 +99,11 @@
        [:button.btn.btn-success
         {:data-dismiss "modal"
          :disabled (< (count @selected) 1)
-         :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
+         :on-click (fn []
+                     ; Merge the new columns into the query
+                     (dispatch [:tree-view/merge-new-columns loc])
+                     ; Close the modal by clearing the modal value in app-db
+                     (dispatch [:prep-modal loc nil]))}
         (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]
       )))
 

--- a/src/im_tables/views/dashboard/save.cljs
+++ b/src/im_tables/views/dashboard/save.cljs
@@ -13,36 +13,40 @@
 (defn save-dialog []
   (let [dom-node (reagent/atom nil)]
     (fn [state-atom details on-submit]
-     [:div.container-fluid
-      {:ref (fn [e] (when e (reset! dom-node e)))}
-      [:div.form
-       [:div.form-group
-        [:label "Name"]
-        [:input.form-control.input-lg
-         {:value (get @state-atom :name)
-          :on-change (fn [e] (swap! state-atom assoc :name (oget e :target :value)))
-          :on-key-up (fn [k] (when (= 13 (oget k :keyCode))
-                               (do
-                                 (on-submit)
-                                 (-> @dom-node js/$ (ocall :closest ".modal") (ocall :modal "hide")))))}]]]])))
+      [:div.container-fluid
+       {:ref (fn [e] (when e (reset! dom-node e)))}
+       [:div.form
+        [:div.form-group
+         [:label "Name"]
+         [:input.form-control.input-lg
+          {:value (get @state-atom :name)
+           :on-change (fn [e] (swap! state-atom assoc :name (oget e :target :value)))
+           :on-key-up (fn [k] (when (= 13 (oget k :keyCode))
+                                (do
+                                  (on-submit)
+                                  (-> @dom-node js/$ (ocall :closest ".modal") (ocall :modal "hide")))))}]]]])))
 
 (defn save-footer []
   (fn [loc state details on-submit]
     [:div.btn-toolbar.pull-right
      [:button.btn.btn-default
-      {:data-dismiss "modal"
-       :on-click (fn [] (dispatch [:prep-modal loc nil]))}
+      {:on-click (fn [] (dispatch [:prep-modal loc nil]))}
       "Cancel"]
      [:button.btn.btn-success
-      {:data-dismiss "modal"
-       :on-click     on-submit}
+      {:on-click on-submit}
       "Save"]]))
 
 (defn generate-dialog [loc {:keys [type count query] :as details}]
   (let [state (reagent/atom {:name (str (name type) " List (" (.toString (js/Date.)) ")")})
-        on-submit (fn [] (dispatch [:imt.io/save-list loc (:name @state) (:query details) @state]))]
+        on-submit (fn []
+                    ; Save the list
+                    (dispatch [:imt.io/save-list loc (:name @state) (:query details) @state])
+                    ; Close the modal by clearing the modal markup in app-db
+                    (dispatch [:prep-modal loc nil])
+
+                    )]
     {:header [:h4 (str "Save a list of " (:count details) " " (if (< count 2) (name type) (plural (name type))))]
-     :body   [save-dialog state details on-submit]
+     :body [save-dialog state details on-submit]
      :footer [save-footer loc state details on-submit]}))
 
 (defn serialize-path [model path]
@@ -63,10 +67,10 @@
                            {
                             ;:data-toggle "modal"
                             ;:data-target "#testModal"
-                            :on-click    (fn [] (dispatch [:prep-modal loc
-                                                           (generate-dialog loc
-                                                                            {:query query
-                                                                             :type  class})]))}
+                            :on-click (fn [] (dispatch [:prep-modal loc
+                                                        (generate-dialog loc
+                                                                         {:query query
+                                                                          :type class})]))}
                            (serialize-path @model path)]]) details))]])))
 
 (defn save-menu []
@@ -75,16 +79,16 @@
      {
       ;:data-toggle "modal"
       ;:data-target "#testModal"
-      :on-click    (fn [] (dispatch [:prep-modal loc
-                                     (generate-dialog loc
-                                                      {:query query
-                                                       :count count
-                                                       :type  (name (path/class model path))})]))}
+      :on-click (fn [] (dispatch [:prep-modal loc
+                                  (generate-dialog loc
+                                                   {:query query
+                                                    :count count
+                                                    :type (name (path/class model path))})]))}
      [:a (str (serialize-path model path) " (" count ")")]]))
 
 
 (defn main [loc]
-  (let [model       (subscribe [:assets/model loc])
+  (let [model (subscribe [:assets/model loc])
         query-parts (subscribe [:main/query-parts loc])]
     (fn [loc]
       [:div.dropdown

--- a/src/im_tables/views/dashboard/save.cljs
+++ b/src/im_tables/views/dashboard/save.cljs
@@ -30,7 +30,8 @@
   (fn [loc state details on-submit]
     [:div.btn-toolbar.pull-right
      [:button.btn.btn-default
-      {:data-dismiss "modal"}
+      {:data-dismiss "modal"
+       :on-click (fn [] (dispatch [:prep-modal loc nil]))}
       "Cancel"]
      [:button.btn.btn-success
       {:data-dismiss "modal"
@@ -59,8 +60,9 @@
         (into [:ul]
               (map (fn [[path query]]
                      [:li [:a
-                           {:data-toggle "modal"
-                            :data-target "#testModal"
+                           {
+                            ;:data-toggle "modal"
+                            ;:data-target "#testModal"
                             :on-click    (fn [] (dispatch [:prep-modal loc
                                                            (generate-dialog loc
                                                                             {:query query
@@ -70,8 +72,9 @@
 (defn save-menu []
   (fn [loc model path {:keys [query count]}]
     [:li
-     {:data-toggle "modal"
-      :data-target "#testModal"
+     {
+      ;:data-toggle "modal"
+      ;:data-target "#testModal"
       :on-click    (fn [] (dispatch [:prep-modal loc
                                      (generate-dialog loc
                                                       {:query query

--- a/src/im_tables/views/table/body/main.cljs
+++ b/src/im_tables/views/table/body/main.cljs
@@ -100,6 +100,7 @@
       (let [{:keys [on-click url vocab]} (get-in @settings [:links])]
 
         [:td
+         ;(or value [no-value])
          (if rows
            ; rows means outer-join, so show outer-join table
            [outer-join-table loc data view]
@@ -122,9 +123,13 @@
                                       (ocall :popover "destroy")))))}
               (or value [no-value])]]])]))))
 
+
 (defn table-row [loc row]
   (into [:tr]
         (map-indexed
           (fn [idx c]
-            ^{:key (str idx (:id c) (:column c))} [cell loc c])
+            ;(reagent/flush)
+            ^{:key idx} [cell loc c]
+            ;[:td (:value c)]
+            )
           row)))

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -7,27 +7,34 @@
             [imcljs.query :as q]
             [clojure.string :refer [split starts-with?]]))
 
+(defn table-head [loc]
+  (let [dragging-item (subscribe [:style/dragging-item loc])
+        dragging-over (subscribe [:style/dragging-over loc])
+        collapsed-views (subscribe [:query-response/views-collapsed-by-joins loc])]
+    (fn [views]
+      [:thead
+       (into [:tr]
+             (->> @collapsed-views
+                  (map-indexed (fn [idx h]
+                                 ^{:key (get views idx)}
+                                 [table-head/header loc
+                                  {:header h
+                                   :dragging-over @dragging-over
+                                   :dragging-item @dragging-item
+                                   :loc loc
+                                   :idx idx
+                                   :subviews nil
+                                   :col-count (count @collapsed-views)
+                                   :view h}]))))])))
+
 (defn main [loc]
-  (let [dragging-item   (subscribe [:style/dragging-item loc])
-        dragging-over   (subscribe [:style/dragging-over loc])
+  (let [dragging-item (subscribe [:style/dragging-item loc])
+        dragging-over (subscribe [:style/dragging-over loc])
         collapsed-views (subscribe [:query-response/views-collapsed-by-joins loc])]
     (fn [loc {:keys [results views]} {:keys [limit start] :or {limit 10 start 0}}]
       [:div.relative
        [:table.table.table-condensed.table-bordered.table-striped
-        [:thead
-         (into [:tr]
-               (->> @collapsed-views
-                    (map-indexed (fn [idx h]
-                                   ^{:key (get views idx)}
-                                   [table-head/header loc
-                                    {:header h
-                                     :dragging-over @dragging-over
-                                     :dragging-item @dragging-item
-                                     :loc loc
-                                     :idx idx
-                                     :subviews nil
-                                     :col-count (count @collapsed-views)
-                                     :view h}]))))]
+        [table-head loc views]
         (into [:tbody]
               (->>
                 (map second (into (sorted-map) (select-keys results (range start (+ start limit)))))

--- a/src/im_tables/views/table/head/main.cljs
+++ b/src/im_tables/views/table/head/main.cljs
@@ -16,7 +16,7 @@
 (defn header [loc]
   (let [model (subscribe [:assets/model loc])
         draggable? (reagent/atom true)]
-    (fn [loc {:keys [idx header view dragging-over dragging-item col-count] :as header}]
+    (fn [loc {:keys [idx header view dragging-over dragging-item col-count] :as data}]
       (let [drag-class (cond
                          (and (= idx dragging-over) (< idx dragging-item)) "drag-left"
                          (and (= idx dragging-over) (> idx dragging-item)) "drag-right")


### PR DESCRIPTION
Updates include:

- Properties of the table are now passed to the view as a map  (`:location :query :service :settings` etc.) 
- Remote assets are fetched and cached if they are missing (the service's model and summary fields)
- The table executes its boot protocol when the view is mounted, removing the need for the table (or parent framework) to dispatch the `[:im-tables.main/replace-all-state]` event.
- Modals no longer use Bootstrap's JS to show/hide themselves
  - Assumes that Bootstrap's CSS is still present to preserve styling across applications
  - When the `:modal` key of app-db contains a value it will be rendered as a modal to the screen using the `{:header .. :body .. :footer}` keys. Clearing the `:modal` key closes the modal, for example: `(dispatch [:prep-modal location nil) `
 although their markup assume bootstrap CSS is present to preserve styling across applications
- Project organisation is now "org.intermine"

For example, to initiate a table, only the view needs to be mounted:

```clojure
[im-tables.views.core/main {:location [:location-in :app-db :to-store-this-tables-data]
                            :service {:root "beta.flymine.org/beta"}
                            :settings {:pagination {:limit 10}}
                            :query {:from "Gene"
                                    :select ["symbol"
                                             "secondaryIdentifier"
                                             "primaryIdentifier"
                                             "organism.name"
                                             "dataSets.name"]
                                    :where [{:path "Gene.symbol"
                                             :op "LIKE"
                                             :value "M*"}]}}]
```


