### PR TITLE
Dropdown placement, icon filter

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -334,7 +334,7 @@
         white-space: nowrap;
 
         .dropdown-menu {
-            min-width: 35vw;
+            min-width: 360px;
             padding: 0;
         }
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/im-tables "0.5.0"
+(defproject org.intermine/im-tables "0.6.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -7,3 +7,8 @@
   :im-tables/im-operation
   (fn [{:keys [on-success on-failure response-format op params]}]
     (go (dispatch (conj on-success (<! (op)))))))
+
+(reg-fx
+  :im-tables/im-operation-chan
+  (fn [{:keys [on-success on-failure response-format channel params]}]
+    (go (dispatch (conj on-success (<! channel))))))

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -15,7 +15,8 @@
             [imcljs.path :as im-path]
             [imcljs.query :as query]
             [oops.core :refer [oapply ocall oget]]
-            [clojure.string :refer [split join starts-with?]]))
+            [clojure.string :refer [split join starts-with?]]
+            [cljs.core.async :refer [close!]]))
 
 (joshkh.undo/undo-config!
   ; This function is used to only store certain parts
@@ -542,21 +543,30 @@
 (reg-event-fx
   :im-tables.main/run-query
   (sandbox)
-  (fn [{db :db} [_ loc merge?]]
-    (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
-      ;(js/console.log "Running query: " loc (get db :query))
-      {:db (assoc-in db [:cache :column-summary] {})
-       ;:undo                   "Undo ran query"
-       :dispatch-n [^:flush-dom [:show-overlay loc]
-                    [:main/deconstruct loc]]
-       :im-tables/im-operation {:on-success (if merge?
-                                              ^:flush-dom [:main/merge-query-response loc pagination]
-                                              ^:flush-dom [:main/replace-query-response loc pagination])
-                                :op (partial fetch/table-rows
+  (let [previous-requests (atom {})]
+    (fn [{db :db} [_ loc merge?]]
+      (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
+        ;(js/console.log "Running query: " loc (get db :query))
+
+        ; Previous requests are stored in an atom containing a map. This is to prevent
+        ; one table from cancelling a pending request belonging to another table.
+
+        ; Close a previous request if it exists for this table's "location"
+        (some-> @previous-requests (get loc) close!)
+        ; Make a new request and replace the old request with the new one
+        (swap! previous-requests assoc loc (fetch/table-rows
                                              (get db :service)
                                              (get db :query)
                                              {:start start
-                                              :size (* limit (get-in db [:settings :buffer]))})}})))
+                                              :size (* limit (get-in db [:settings :buffer]))}))
+        {:db (assoc-in db [:cache :column-summary] {})
+         :dispatch-n [^:flush-dom [:show-overlay loc]
+                      [:main/deconstruct loc]]
+         :im-tables/im-operation-chan {:on-success (if merge?
+                                                     ^:flush-dom [:main/merge-query-response loc pagination]
+                                                     ^:flush-dom [:main/replace-query-response loc pagination])
+                                       ; Hand the request atom off to the effect that takes from it
+                                       :channel (get @previous-requests loc)}}))))
 
 
 

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -33,6 +33,9 @@
         [:div.modal-body body]
         [:div.modal-footer footer]]]]]))
 
+(defn constraint-has-path? [view constraint]
+  (= view (:path constraint)))
+
 (defn main [{:keys [location]} state]
   (let [response (subscribe [:main/query-response location])
         pagination (subscribe [:settings/pagination location])
@@ -68,7 +71,8 @@
                  (into [:tr]
                        (->> @collapsed-views
                             (map-indexed (fn [idx h]
-                                           (let [display-name (when (and @model h) (impath/display-name @model h))]
+                                           (let [display-name (when (and @model h) (impath/display-name @model h))
+                                                 active-filters (not-empty (filter (partial constraint-has-path? h) (:where query)))]
                                              ; This is a simple HTML representation of
                                              ; im-tables.views.table.head.controls/toolbar
                                              ; If you modify this form or the one in the toolbar, please remember to modify both
@@ -77,7 +81,8 @@
                                               [:div.summary-toolbar
                                                [:i.fa.fa-sort.sort-icon]
                                                [:i.fa.fa-times.remove-icon]
-                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon]
+                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon
+                                                {:class (when active-filters "active-filter")}]
                                                [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
                                               [:div
                                                [:div (last (drop-last display-name))]

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -226,7 +226,7 @@
          :class (cond active-filters? "active-filter")
          :title (str "Filter " view " column")}]
        ; Crudely try to draw the dropdown near the middle of the page
-       [:div.dropdown-menu {:class (if (> idx (/ col-count 2)) "dropdown-right" "dropdown-left")} [filter-view loc view blank-constraint-atom]]])))
+       [:div.dropdown-menu [filter-view loc view blank-constraint-atom]]])))
 
 (defn toolbar []
   (fn [loc view idx col-count]

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -49,8 +49,12 @@
      [:option {:value ">"} "greater than"]
      [:option {:value "<"} "less than"]
      [:option {:value "="} "equal to"]
+     [:option {:value "!="} "not equal to"]
+     [:option {:value "LIKE"} "like"]
+     [:option {:value "NOT LIKE"} "not like"]
      [:option {:value "CONTAINS"} "contains"]
-     [:option {:value "ONE OF"} "one of"]]))
+     [:option {:value "ONE OF"} "one of"]
+     [:option {:value "NONE OF"} "none of"]]))
 
 (defn constraint-text []
   (fn [{:keys [value on-change]}]


### PR DESCRIPTION
Included in pull request:

* Column summaries now have a fixed min-width. 35vw caused the column summaries to grow very wide on large screens.
* Column summary dropdowns no longer try to calculate their left / right classes based on their column index.
* Icon filter stays highlighted when a column has a constraint (bug fix) 