### PR TITLE
Pagination

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -30,6 +30,7 @@
 }
 
 .im-table {
+
     @spacer: 1em;
     @highlightcolor: cornflowerblue;
     @drag-color: #337ab7; //why isn't "fabulous and glittery" a colour?
@@ -43,6 +44,12 @@
         padding: 0;
         .table {
             margin: 0;
+        }
+    }
+
+    .pagination-bar {
+        label {
+            line-height: 2.4em;
         }
     }
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/im-tables "0.6.0-SNAPSHOT"
+(defproject org.intermine/im-tables "0.7.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/im-tables "0.7.0-SNAPSHOT"
+(defproject org.intermine/im-tables "0.7.0"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -14,7 +14,7 @@
                                              "dataSets.name"]
                                     :where [{:path "Gene.symbol"
                                              :op "LIKE"
-                                             :value "M01A1**"}]}
+                                             :value "M01*"}]}
                             :settings {:pagination {:limit 10}
                                        :links {:vocab {:mine "BananaMine"}
                                                :url (fn [vocab] (str "#/reportpage/"

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -14,7 +14,7 @@
                                              "dataSets.name"]
                                     :where [{:path "Gene.symbol"
                                              :op "LIKE"
-                                             :value "M01*"}]}
+                                             :value "M0*"}]}
                             :settings {:pagination {:limit 10}
                                        :links {:vocab {:mine "BananaMine"}
                                                :url (fn [vocab] (str "#/reportpage/"

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -14,7 +14,7 @@
                                              "dataSets.name"]
                                     :where [{:path "Gene.symbol"
                                              :op "LIKE"
-                                             :value "M0*"}]}
+                                             :value "M01*"}]}
                             :settings {:pagination {:limit 10}
                                        :links {:vocab {:mine "BananaMine"}
                                                :url (fn [vocab] (str "#/reportpage/"

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -33,13 +33,13 @@
        ]
       [:div.col-xs-4
        [:div.container-fluid
-        [:div.row
-         [:div.col-xs-offset-2
+        [:div.row.pagination-bar
+         [:div.col-xs-12
           [:div.pull-right
            [:div.pull-right [pager/main loc
                              (merge pagination
                                     {:total (get response :iTotalRecords)})]]
-           [:span.pull-right
+           [:label.pull-right
             {:style {:padding-right "20px"}}
             (when (:iTotalRecords response)
               (str "Showing "

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -15,7 +15,7 @@
      [:div.row
       [column-manager/main loc]]
      [:div.row.im-table-toolbar
-      [:div.col-xs-8
+      [:div.col-md-8
        [:div.btn-toolbar
 
         [:div.btn-group
@@ -31,7 +31,7 @@
         [undo/main loc]
         ]
        ]
-      [:div.col-xs-4
+      [:div.col-md-4
        [:div.container-fluid
         [:div.row.pagination-bar
          [:div.col-xs-12

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -3,7 +3,7 @@
             [clojure.string :refer [split]]
             [oops.core :refer [oget]]))
 
-(def show-amounts (list 10 20 50))
+(def show-amounts (list 10 20 50 100 250))
 
 
 
@@ -18,7 +18,7 @@
               :on-change (fn [e]
                            (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
             (cond-> (map (fn [a] [:option {:value a} a]) (take-while (partial > total) show-amounts))
-                    total (concat (list [:option {:value total} (str "All (" total ")")]))))]
+                    (and total (< total 250)) (concat (list [:option {:value total} (str "All (" total ")")]))))]
      [:div.btn-group
       [:button.btn.btn-default
        {:disabled (< start 1)

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -11,17 +11,14 @@
   (fn [loc {:keys [start limit total]}]
     [:div.btn-toolbar
      [:div.btn-group
-      [:label "Show"]]
+      [:label "Rows per page"]]
      [:div.btn-group
       (into [:select.form-control
-             {:value limit
+             {:value     (or limit "")
               :on-change (fn [e]
                            (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
-            (concat
-              (map (fn [a]
-                     [:option {:value a} a])
-                   (take-while (partial > total) show-amounts))
-              (list [:option {:value total} (str "All (" total ")")])))]
+            (cond-> (map (fn [a] [:option {:value a} a]) (take-while (partial > total) show-amounts))
+                    total (concat (list [:option {:value total} (str "All (" total ")")]))))]
      [:div.btn-group
       [:button.btn.btn-default
        {:disabled (< start 1)

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -32,11 +32,11 @@
       [:label (str "Page " (inc (/ start limit)))]]
      [:div.btn-group
       [:button.btn.btn-default
-       {:disabled (< (- total start) limit)
+       {:disabled (<= (- total start) limit)
         :on-click (fn [] (dispatch ^:flush-dom [:imt.settings/update-pagination-inc loc]))}
        [:span.glyphicon.glyphicon-triangle-right]]
       [:button.btn.btn-default
-       {:disabled (< (- total start) limit)
+       {:disabled (<= (- total start) limit)
         :on-click (fn [] (dispatch [:imt.settings/update-pagination-fullinc loc]))}
        [:span.glyphicon.glyphicon-step-forward]]]]))
 

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -1,11 +1,28 @@
 (ns im-tables.views.dashboard.pagination
   (:require [re-frame.core :refer [subscribe dispatch]]
-            [clojure.string :refer [split]]))
+            [clojure.string :refer [split]]
+            [oops.core :refer [oget]]))
+
+(def show-amounts (list 10 20 50))
+
+
 
 (defn main []
   (fn [loc {:keys [start limit total]}]
     [:span.pagination-bar
      [:div.btn-toolbar
+      [:div.btn-group
+       [:label "Show"]]
+      [:div.btn-group
+       (into [:select.form-control
+              {:value limit
+               :on-change (fn [e]
+                            (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
+             (concat
+               (map (fn [a]
+                     [:option {:value a} a])
+                    (take-while (partial > total) show-amounts))
+               (list [:option {:value total} (str "All (" total ")")])))]
       [:div.btn-group
        [:button.btn.btn-default
         {:disabled (< start 1)

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -9,40 +9,39 @@
 
 (defn main []
   (fn [loc {:keys [start limit total]}]
-    [:span.pagination-bar
-     [:div.btn-toolbar
-      [:div.btn-group
-       [:label "Show"]]
-      [:div.btn-group
-       (into [:select.form-control
-              {:value limit
-               :on-change (fn [e]
-                            (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
-             (concat
-               (map (fn [a]
+    [:div.btn-toolbar
+     [:div.btn-group
+      [:label "Show"]]
+     [:div.btn-group
+      (into [:select.form-control
+             {:value limit
+              :on-change (fn [e]
+                           (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
+            (concat
+              (map (fn [a]
                      [:option {:value a} a])
-                    (take-while (partial > total) show-amounts))
-               (list [:option {:value total} (str "All (" total ")")])))]
-      [:div.btn-group
-       [:button.btn.btn-default
-        {:disabled (< start 1)
-         :on-click (fn [] (dispatch [:imt.settings/update-pagination-fulldec loc]))}
-        [:span.glyphicon.glyphicon-step-backward]]
-       [:button.btn.btn-default
-        {:disabled (< start 1)
-         :on-click (fn [] (dispatch [:imt.settings/update-pagination-dec loc]))}
-        [:span.glyphicon.glyphicon-triangle-left]]]
-      [:div.btn-group
-       [:div (str "Page " (inc (/ start limit)))]]
-      [:div.btn-group
-       [:button.btn.btn-default
-        {:disabled (< (- total start) limit)
-         :on-click (fn [] (dispatch ^:flush-dom [:imt.settings/update-pagination-inc loc]))}
-        [:span.glyphicon.glyphicon-triangle-right]]
-       [:button.btn.btn-default
-        {:disabled (< (- total start) limit)
-         :on-click (fn [] (dispatch [:imt.settings/update-pagination-fullinc loc]))}
-        [:span.glyphicon.glyphicon-step-forward]]]]]))
+                   (take-while (partial > total) show-amounts))
+              (list [:option {:value total} (str "All (" total ")")])))]
+     [:div.btn-group
+      [:button.btn.btn-default
+       {:disabled (< start 1)
+        :on-click (fn [] (dispatch [:imt.settings/update-pagination-fulldec loc]))}
+       [:span.glyphicon.glyphicon-step-backward]]
+      [:button.btn.btn-default
+       {:disabled (< start 1)
+        :on-click (fn [] (dispatch [:imt.settings/update-pagination-dec loc]))}
+       [:span.glyphicon.glyphicon-triangle-left]]]
+     [:div.btn-group
+      [:label (str "Page " (inc (/ start limit)))]]
+     [:div.btn-group
+      [:button.btn.btn-default
+       {:disabled (< (- total start) limit)
+        :on-click (fn [] (dispatch ^:flush-dom [:imt.settings/update-pagination-inc loc]))}
+       [:span.glyphicon.glyphicon-triangle-right]]
+      [:button.btn.btn-default
+       {:disabled (< (- total start) limit)
+        :on-click (fn [] (dispatch [:imt.settings/update-pagination-fullinc loc]))}
+       [:span.glyphicon.glyphicon-step-forward]]]]))
 
 
 


### PR DESCRIPTION
Users can now select the number of rows per page.

* Rows per page range from (list 10 20 50 100 250)
* Only show ranges that are below the result count (for instance, only show 10, 20, and 50 for a query that returns 38 results)
* Show All (row count) option when the results are less than 250