### PR TITLE
URL Fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.intermine/im-tables "0.7.0"
+(defproject org.intermine/im-tables "0.7.1"
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/clojurescript "1.9.671"]
                  [reagent "0.7.0" :exclusions [cljsjs/react]]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -20,7 +20,7 @@
                                                :url (fn [vocab] (str "#/reportpage/"
                                                                      (:mine vocab) "/"
                                                                      (:class vocab) "/"
-                                                                     (:objectId vocab)))}}})
+                                                                     (:id vocab)))}}})
 
 ; This function is used for testing purposes.
 ; When using im-tables in real life, you could call the view like so:

--- a/src/im_tables/views/table/body/main.cljs
+++ b/src/im_tables/views/table/body/main.cljs
@@ -105,9 +105,12 @@
            [outer-join-table loc data view]
            ; otherwise a regular cell
            [:span {:ref (fn [p] (when p (reset! pop-el p)))} ; Store a reference so we can manually kill popups
+
             [poppable {:on-mouse-enter (fn [] (dispatch [:main/summarize-item loc data]))
                        :data-content (->html (summary-table @(subscribe [:summary/item-details loc id])))}
+
              [:a {:href (url (merge
+                               data
                                (:value @(subscribe [:summary/item-details loc id]))
                                (get-in @settings [:links :vocab])))
                   :on-click (fn []
@@ -115,6 +118,7 @@
                                 (do
                                   ; Call the provided on-click
                                   (on-click (url (merge
+                                                   data
                                                    (:value @(subscribe [:summary/item-details loc id]))
                                                    (get-in @settings [:links :vocab]))))
                                   ; Side effect!!


### PR DESCRIPTION
This branch makes sure to pass already fetched table cell data (such as class and id) to the user-provided function that builds a URL.

To test:

1. Load the table.
2. Slow network down to Slow 3G
3. Observe that the href for a given cell includes the Class and object ID before the popover has loaded