### PR TITLE
Wait with additional requests until table is interacted with

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,25 @@ You will often see location passed to the outermost function, but don't be caugh
 
 When a table first loads it only renders the first page of the query results as bog standard html with minimal components. This allows many tables to be rendered to, say, a report page while reducing load on the browser. Mousing over the table triggers a change that forces the table into "React" mode when the table cells become more complex.
 
-
+## Building
 
 ### Initial setup
 Once you've checked this project, you'll need to download the css dependencies using [bower](https://bower.io/). Assuming you have bower installed already, it's just
 
 ```
 bower install
+```
+
+### Quickstart
+
+These commands are explained in more depth below, but if you know what you want here's a quick reference of the most useful ones.
+
+```
+lein dev         # start dev server with hot-reloading
+lein repl        # start dev server with hot-reloading and nrepl (no clean or css)
+lein deploy      # build prod release and deploy to clojars
+
+lein format      # run cljfmt to fix code indentation
 ```
 
 ### Compile css:
@@ -143,6 +155,8 @@ The above command assumes that you have [phantomjs](https://www.npmjs.com/packag
 
 ## Production Build
 
+### Deploying to Heroku
+
 ```
 lein clean
 lein uberjar
@@ -171,3 +185,12 @@ To compile clojurescript to javascript:
 lein clean
 lein cljsbuild once min
 ```
+
+### Releasing a new version
+
+The release process is a combination of the above commands, with some additional steps. Generally, you'll want to do the following.
+
+1. Update the version number in **project.clj**.
+1. Commit this change and tag it using `git tag -a v1.0.0 -m "Release v1.0.0"`, replacing *1.0.0* with your version number.
+1. Push your commit and tag using `git push origin` followed by `git push origin v1.0.0` (again replace *1.0.0* with your version number). Make sure that you push to the intermine repository, not just your fork!
+1. Deploy a new uberjar to Clojars with `lein deploy`.

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,7 @@
+;; This namespace starts figwheel as part of the aliases:
+;;     lein dev
+;;     lein repl
+(ns user
+  (:require [figwheel-sidecar.repl-api :refer [start-figwheel!]]))
+
+(start-figwheel!)

--- a/src/im_tables/components/bootstrap.cljs
+++ b/src/im_tables/components/bootstrap.cljs
@@ -3,7 +3,6 @@
             [reagent.dom.server :as server]
             [oops.core :refer [ocall oapply oget oset!]]))
 
-
 (defn popover
   "Reagent wrapper for bootstrap's popover component. It accepts
   hiccup-style syntax in its :data-content attribute.
@@ -13,8 +12,7 @@
                  :data-content [:div [:h1 Hello] [:h4 Goodbye]]} Hover-Over-Me]]"
   []
   (reagent/create-class
-    {
-     ;:component-did-mount
+   {;:component-did-mount
      ;(fn [this]
      ;  (let [node (reagent/dom-node this)] (ocall (-> node js/$) "popover")))
      ;:component-will-unmount
@@ -26,34 +24,33 @@
      ;  (let [node (reagent/dom-node this)]
      ;    (ocall (-> "popover" js/$) "remove")
      ;    (ocall (-> node js/$) "popover")))
-     :component-did-mount
-     (fn [this]
+    :component-did-mount
+    (fn [this])
        ;(.log js/console "d" (ocall (js/$ (reagent/dom-node this)) "popover"))
-       )
-     :component-did-update
-     (fn [this]
-       (.log js/console "me" (js/$ (reagent/dom-node this)))
-       (-> (js/$ (reagent/dom-node this))
-           ;(ocall "popover" "destroy")
-           (ocall "popover" "toggle")))
-     :reagent-render
-     (fn [[element attributes & rest]]
-       [element (-> attributes
-                    (assoc :data-html true)
-                    (assoc :data-container "body")
-                    (update :data-content server/render-to-static-markup)) rest])}))
 
+    :component-did-update
+    (fn [this]
+      (.log js/console "me" (js/$ (reagent/dom-node this)))
+      (-> (js/$ (reagent/dom-node this))
+           ;(ocall "popover" "destroy")
+          (ocall "popover" "toggle")))
+    :reagent-render
+    (fn [[element attributes & rest]]
+      [element (-> attributes
+                   (assoc :data-html true)
+                   (assoc :data-container "body")
+                   (update :data-content server/render-to-static-markup)) rest])}))
 
 (defn inner-tooltip []
   (fn [parent-data show-atom content]
     (reagent/create-class
-      {:name "ARROWBOX"
-       :reagent-render
-             [:div.arrow_box
-              {:on-mouse-enter (fn [] (reset! show-atom false))
-               :style          {:position "absolute"
-                                :top      (:height parent-data)}}
-              content]})))
+     {:name "ARROWBOX"
+      :reagent-render
+      [:div.arrow_box
+       {:on-mouse-enter (fn [] (reset! show-atom false))
+        :style          {:position "absolute"
+                         :top      (:height parent-data)}}
+       content]})))
 
 (defn tooltip
   "Reagent wrapper for bootstrap's popover component. It accepts
@@ -66,43 +63,41 @@
   (let [mystate (reagent/atom {})
         show?   (reagent/atom false)]
     (reagent/create-class
-      {:name "Tooltip"
-       :component-did-mount
-             (fn [this]
-               (let [bb (ocall (reagent/dom-node this) "getBoundingClientRect")]
-                 (swap! mystate assoc
-                        :width (oget bb "width")
-                        :height (oget bb "height")
-                        :left (oget bb "left")
-                        :right (oget bb "right")
-                        :top (oget bb "top")
-                        :bottom (oget bb "bottom"))))
-       :component-did-update
-             (fn [this])
-       :reagent-render
-             (fn [[element attributes & rest]]
-               [element (-> attributes
-                            (assoc :on-mouse-enter (fn []
-                                                     (do
-                                                       (if-let [f (:on-mouse-enter attributes)] (f))
-                                                       (reset! show? true))))
-                            (assoc :on-mouse-leave (fn [x]
-                                                     (do
-                                                       (if-let [f (:on-mouse-leave attributes)] (f))
-                                                       (reset! show? false)))))
-                (if @show?
-                  [:div.test
-                   [:div.arrow_box
-                    {:on-mouse-enter (fn [] (reset! show? false))
-                     :style          {:position "absolute"
-                                      :top      (:height @mystate)}}
-                    (:data-content attributes)]]
+     {:name "Tooltip"
+      :component-did-mount
+      (fn [this]
+        (let [bb (ocall (reagent/dom-node this) "getBoundingClientRect")]
+          (swap! mystate assoc
+                 :width (oget bb "width")
+                 :height (oget bb "height")
+                 :left (oget bb "left")
+                 :right (oget bb "right")
+                 :top (oget bb "top")
+                 :bottom (oget bb "bottom"))))
+      :component-did-update
+      (fn [this])
+      :reagent-render
+      (fn [[element attributes & rest]]
+        [element (-> attributes
+                     (assoc :on-mouse-enter (fn []
+                                              (do
+                                                (if-let [f (:on-mouse-enter attributes)] (f))
+                                                (reset! show? true))))
+                     (assoc :on-mouse-leave (fn [x]
+                                              (do
+                                                (if-let [f (:on-mouse-leave attributes)] (f))
+                                                (reset! show? false)))))
+         (if @show?
+           [:div.test
+            [:div.arrow_box
+             {:on-mouse-enter (fn [] (reset! show? false))
+              :style          {:position "absolute"
+                               :top      (:height @mystate)}}
+             (:data-content attributes)]])
 
                   ;[inner-tooltip @mystate show? (:data-content attributes)]
-                  )
-                rest])})))
 
-
+         rest])})))
 
 (defn modal []
   (fn [{:keys [header body footer]}]

--- a/src/im_tables/core.clj
+++ b/src/im_tables/core.clj
@@ -1,0 +1,7 @@
+(ns im-tables.core)
+
+(defn -main
+  "Dummy main method that doesn't do anything. This namespace exists only
+  so we can use `lein run` even though this project is CLJS only."
+  [& _args]
+  nil)

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -7,7 +7,6 @@
             [im-tables.views :as views]
             [im-tables.config :as config]
             [imcljs.query :as query]
-            [re-frisk.core :refer [enable-re-frisk!]]
             [cljsjs.react-transition-group]
             [cljsjs.highlight]
             [cljsjs.highlight.langs.javascript]
@@ -16,11 +15,9 @@
             [cljsjs.highlight.langs.ruby]
             [cljsjs.highlight.langs.java]))
 
-
 (defn dev-setup []
   (when config/debug?
     (enable-console-print!)
-    (enable-re-frisk!)
     (println "dev mode")))
 
 (defn mount-root []

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -29,11 +29,10 @@
 
 (defn ^:export init []
   #_(re-frame/dispatch-sync [:initialize-db
-                           [:test :location]
-                           {
-                            :service {:root "www.flymine.org/query"}
-                            ;:service {:root "yeastmine.yeastgenome.org/yeastmine"}
-                            :query (query/sterilize-query db/outer-join-query)}])
+                             [:test :location]
+                             {:service {:root "www.flymine.org/query"}
+                              ;:service {:root "yeastmine.yeastgenome.org/yeastmine"}
+                              :query (query/sterilize-query db/outer-join-query)}])
 
   (dev-setup)
   (mount-root))

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -35,12 +35,10 @@
                        :size 10
                        :sortOrder [{:path "symbol"
                                     :direction "ASC"}]
-                       :where [
-                               {:path "secondaryIdentifier"
+                       :where [{:path "secondaryIdentifier"
                                 :op "="
                                 :value "AC3.1*" ;AC3*
-                                :code "A"}
-                               ]})
+                                :code "A"}]})
 
 (def list-query {:title "esyN demo list"
                  :from "Gene"
@@ -48,9 +46,7 @@
                  :where [{:path "Gene", :op "IN", :value "esyN demo list"}]})
 
 (def default-db
-  {
-
-   ;:service  {:root "www.flymine.org/query"}
+  {;:service  {:root "www.flymine.org/query"}
    ;:query    {:from   "Gene"
    ;           :size   10
    ;           :select ["secondaryIdentifier"

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -4,11 +4,11 @@
             [cljs.core.async :refer [<! timeout close!]]))
 
 (reg-fx
-  :im-tables/im-operation
-  (fn [{:keys [on-success on-failure response-format op params]}]
-    (go (dispatch (conj on-success (<! (op)))))))
+ :im-tables/im-operation
+ (fn [{:keys [on-success on-failure response-format op params]}]
+   (go (dispatch (conj on-success (<! (op)))))))
 
 (reg-fx
-  :im-tables/im-operation-chan
-  (fn [{:keys [on-success on-failure response-format channel params]}]
-    (go (dispatch (conj on-success (<! channel))))))
+ :im-tables/im-operation-chan
+ (fn [{:keys [on-success on-failure response-format channel params]}]
+   (go (dispatch (conj on-success (<! channel))))))

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -533,7 +533,13 @@
 
 ;;;;;;;;;;;;;;
 
-
+(reg-event-db
+  :main/initial-query-response
+  (sandbox)
+  (fn [db [_ loc {:keys [start]} results]]
+    (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
+          updated-results (assoc results :results new-results-map)]
+      (assoc db :response updated-results))))
 
 (reg-event-fx
   :main/replace-query-response

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -24,20 +24,20 @@
   ; This function is used to only store certain parts
   ; of our app-db. We're specifically ignoring anything
   ; in the :cache or :response (query results) keys
-  {:harvest-fn (fn [ratom location]
-                 (-> @ratom
+ {:harvest-fn (fn [ratom location]
+                (-> @ratom
                      ; The ratom contains all undos for all tables;
                      ; so only be sure to only look in THIS table's location
-                     (get-in location)
+                    (get-in location)
                      ; These keys' values will be stored in the undo stack for this table's location.
                      ; Query is kept because duh. Keeping :settings means restoring our pagination
                      ; and temp-query is used by various controls as a staging area before merging the
                      ; changes into the :query key and running it
-                     (select-keys [:query :settings :temp-query])))
+                    (select-keys [:query :settings :temp-query])))
    ; This function is used to put some old state back into our app-db
-   :reinstate-fn (fn [ratom value location]
+  :reinstate-fn (fn [ratom value location]
                    ; Ratom is our app-db
-                   (swap! ratom update-in location merge value))
+                  (swap! ratom update-in location merge value))
    ; This function fires after EITHER an :undo or a :redo takes place
    ; We're not storing any "side effect" data, such as query results because we have no control over them.
    ; Most undo events modify the underlying query so it makes sense re-run it when the query has been
@@ -46,14 +46,14 @@
    ; If we ever need some undos to *not* re-run a query then consider modifying the :undo effect
    ; to either accept an optional function to run (or at least a flag to run / not run this one.
    ; I didn't do this because I'm lazy.
-   :post-reinstate-fn (fn [location]
-                        (dispatch [:im-tables.main/run-query location]))})
+  :post-reinstate-fn (fn [location]
+                       (dispatch [:im-tables.main/run-query location]))})
 
 (reg-event-db
-  :printdb
-  (fn [db]
-    (.log js/console "DB" db)
-    db))
+ :printdb
+ (fn [db]
+   (.log js/console "DB" db)
+   db))
 
 (defn deep-merge
   "Recursively merges maps. If keys are not maps, the last value wins."
@@ -63,61 +63,58 @@
     (last vals)))
 
 (reg-event-fx
-  :im-tables.main/replace-all-state
-  (sandbox)
-  (fn [_ [_ loc state]]
-    {:db (deep-merge db/default-db state)
-     :dispatch [:im-tables.main/run-query loc]}))
+ :im-tables.main/replace-all-state
+ (sandbox)
+ (fn [_ [_ loc state]]
+   {:db (deep-merge db/default-db state)
+    :dispatch [:im-tables.main/run-query loc]}))
 
 (reg-event-db
-  :imt.io/save-list-success
-  (fn [db [_ response]]
-    (.debug js/console "List Saved" response)
-    db))
-
-
-(reg-event-fx
-  :imt.io/save-list
-  (sandbox)
-  (fn [{db :db} [_ loc name query options]]
-    {:db db
-     :im-tables/im-operation {:on-success [:imt.io/save-list-success]
-                              :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins) options)}}))
+ :imt.io/save-list-success
+ (fn [db [_ response]]
+   (.debug js/console "List Saved" response)
+   db))
 
 (reg-event-fx
-  :prep-modal
-  [(sandbox)]
-  (fn [{db :db} [_ loc contents]]
-    {:db (assoc-in db [:cache :modal] contents)}))
+ :imt.io/save-list
+ (sandbox)
+ (fn [{db :db} [_ loc name query options]]
+   {:db db
+    :im-tables/im-operation {:on-success [:imt.io/save-list-success]
+                             :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins) options)}}))
 
 (reg-event-fx
-  :modal/close
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    (let [modal (ocall js/document :getElementById "testModal")]
+ :prep-modal
+ [(sandbox)]
+ (fn [{db :db} [_ loc contents]]
+   {:db (assoc-in db [:cache :modal] contents)}))
+
+(reg-event-fx
+ :modal/close
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [modal (ocall js/document :getElementById "testModal")]
       ;;feigning a click is easier than dismissing it programatically for some reason
-      (ocall modal "click"))
-    {:db (assoc-in db [:cache :modal] nil)}))
+     (ocall modal "click"))
+   {:db (assoc-in db [:cache :modal] nil)}))
 
 (reg-event-db
-  :show-overlay
-  (sandbox)
-  (fn [db [_ loc]]
-    (assoc-in db [:cache :overlay?] true)))
+ :show-overlay
+ (sandbox)
+ (fn [db [_ loc]]
+   (assoc-in db [:cache :overlay?] true)))
 
 (reg-event-db
-  :show-overlay
-  (sandbox)
-  (fn [db [_ location value]]
-    (update-in db location assoc-in [:cache :overlay?] value)))
+ :show-overlay
+ (sandbox)
+ (fn [db [_ location value]]
+   (update-in db location assoc-in [:cache :overlay?] value)))
 
 (reg-event-db
-  :hide-overlay
-  (sandbox)
-  (fn [db [_ loc]]
-    (assoc-in db [:cache :overlay?] false)))
-
-
+ :hide-overlay
+ (sandbox)
+ (fn [db [_ loc]]
+   (assoc-in db [:cache :overlay?] false)))
 
 (defn toggle-into-set [haystack needle]
   (if (some #{needle} haystack)
@@ -132,6 +129,7 @@
 
 ;;;; FILTERS
 
+
 (def alphabet (clojure.string/split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ""))
 
 (defn haystack-has? [haystack needle]
@@ -141,140 +139,134 @@
   (first (drop-while (partial haystack-has? letters) alphabet)))
 
 (reg-event-db
-  :main/set-temp-query
-  (sandbox)
-  (fn [db [_ loc]]
-    (assoc db :temp-query (get db :query))))
+ :main/set-temp-query
+ (sandbox)
+ (fn [db [_ loc]]
+   (assoc db :temp-query (get db :query))))
 
 (reg-event-fx
-  :filters/update-constraint
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc new-constraint]]
-    {:db (update-in db [:temp-query :where]
-                    (fn [constraints]
-                      (map (fn [constraint]
-                             (if (= (:code new-constraint) (:code constraint))
-                               new-constraint
-                               constraint)) constraints)))
+ :filters/update-constraint
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc new-constraint]]
+   {:db (update-in db [:temp-query :where]
+                   (fn [constraints]
+                     (map (fn [constraint]
+                            (if (= (:code new-constraint) (:code constraint))
+                              new-constraint
+                              constraint)) constraints)))}))
      ;:undo {:message [:div
      ;                 (str "Added " (count columns-to-add) " new column" (when (> (count columns-to-add) 1) "s"))
      ;                 (into [:div] (map (fn [s] [:span.label.label-default s]) columns-to-add))]
      ;       :location loc}
-     }))
-
-
-
-(reg-event-fx
-  :filters/add-constraint
-  (sandbox)
-  (fn [{db :db} [_ loc new-constraint]]
-    {:db (update-in db [:temp-query :where]
-                    (fn [constraints]
-                      (conj constraints (assoc new-constraint :code (first-letter (map :code constraints))))))}))
 
 
 (reg-event-fx
-  :filters/remove-constraint
-  (sandbox)
-  (fn [{db :db} [_ loc new-constraint]]
-    {:db (update-in db [:temp-query :where]
-                    (fn [constraints]
-                      (remove nil? (map (fn [constraint]
-                                          (if (= constraint new-constraint)
-                                            nil
-                                            constraint)) constraints))))}))
+ :filters/add-constraint
+ (sandbox)
+ (fn [{db :db} [_ loc new-constraint]]
+   {:db (update-in db [:temp-query :where]
+                   (fn [constraints]
+                     (conj constraints (assoc new-constraint :code (first-letter (map :code constraints))))))}))
 
 (reg-event-fx
-  :filters/save-changes
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc]]
-    (let [added (not-empty (clojure.set/difference (set (:where (:temp-query db))) (set (:where (:query db)))))
-          removed (not-empty (clojure.set/difference (set (:where (:query db))) (set (:where (:temp-query db)))))
-          model (get-in db [:service :model])]
+ :filters/remove-constraint
+ (sandbox)
+ (fn [{db :db} [_ loc new-constraint]]
+   {:db (update-in db [:temp-query :where]
+                   (fn [constraints]
+                     (remove nil? (map (fn [constraint]
+                                         (if (= constraint new-constraint)
+                                           nil
+                                           constraint)) constraints))))}))
+
+(reg-event-fx
+ :filters/save-changes
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc]]
+   (let [added (not-empty (clojure.set/difference (set (:where (:temp-query db))) (set (:where (:query db)))))
+         removed (not-empty (clojure.set/difference (set (:where (:query db))) (set (:where (:temp-query db)))))
+         model (get-in db [:service :model])]
       ; This event is usually fired when the filter dropdown closed which means it's fired
       ; a lot even when not necessary. To prevent multiple blank undos from piling up, we only
       ; attach the :undo side effect when something was actually added or removed from the query
-      (cond->
-        {:db (assoc db :query (get db :temp-query))}
-        (or added removed) (assoc :undo {:message [:div
-                                                   (when added
-                                                     [:div
-                                                      [:div "Added filters"]
-                                                      (into [:span]
-                                                            (map (fn [{:keys [path op value]}]
-                                                                   [:div.table-history-detail
-                                                                    [:div (str (im-path/friendly model path))]
-                                                                    [:div (str op " " value)]]) added))])
-                                                   (when removed
-                                                     [:div
-                                                      [:div "Removed filters"]
-                                                      (into [:span]
-                                                            (map (fn [{:keys [path op value]}]
-                                                                   [:div.table-history-detail
-                                                                    [:div (str (im-path/friendly model path))]
-                                                                    [:div (str op " " value)]]) removed))])]
-                                         :location loc})
-        (or added removed) (assoc :dispatch [:im-tables.main/run-query loc])))))
+     (cond-> {:db (assoc db :query (get db :temp-query))}
+       (or added removed) (assoc :undo {:message [:div
+                                                  (when added
+                                                    [:div
+                                                     [:div "Added filters"]
+                                                     (into [:span]
+                                                           (map (fn [{:keys [path op value]}]
+                                                                  [:div.table-history-detail
+                                                                   [:div (str (im-path/friendly model path))]
+                                                                   [:div (str op " " value)]]) added))])
+                                                  (when removed
+                                                    [:div
+                                                     [:div "Removed filters"]
+                                                     (into [:span]
+                                                           (map (fn [{:keys [path op value]}]
+                                                                  [:div.table-history-detail
+                                                                   [:div (str (im-path/friendly model path))]
+                                                                   [:div (str op " " value)]]) removed))])]
+                                        :location loc})
+       (or added removed) (assoc :dispatch [:im-tables.main/run-query loc])))))
 
 ;;;; TRANSIENT VALUES
 
 ;TODO turn stub into working code
 (reg-event-db
-  :select/toggle-selection
-  (sandbox)
-  (fn [db [_ loc view value]]
-    (update-in db [:cache :column-summary view :selections] flip-presence value)))
+ :select/toggle-selection
+ (sandbox)
+ (fn [db [_ loc view value]]
+   (update-in db [:cache :column-summary view :selections] flip-presence value)))
 
 (reg-event-db
-  :select/clear-selection
-  (sandbox)
-  (fn [db [_ loc view]]
-    (assoc-in db [:cache :column-summary view :selections] {})))
+ :select/clear-selection
+ (sandbox)
+ (fn [db [_ loc view]]
+   (assoc-in db [:cache :column-summary view :selections] {})))
 
 (reg-event-db
-  :select/select-all
-  (sandbox)
-  (fn [db [_ loc view]]
-    (assoc-in db [:cache :column-summary view :selections]
-              (into {} (map (fn [{item :item}] [item true]) (get-in db [:cache :column-summary view :response :results]))))))
+ :select/select-all
+ (sandbox)
+ (fn [db [_ loc view]]
+   (assoc-in db [:cache :column-summary view :selections]
+             (into {} (map (fn [{item :item}] [item true]) (get-in db [:cache :column-summary view :response :results]))))))
 
 (reg-event-db
-  :select/set-text-filter
-  (sandbox)
-  (fn [db [_ loc view value]]
-    (assoc-in db [:cache :column-summary view :filters :text]
-              (if (= value "") nil value))))
+ :select/set-text-filter
+ (sandbox)
+ (fn [db [_ loc view value]]
+   (assoc-in db [:cache :column-summary view :filters :text]
+             (if (= value "") nil value))))
 
 ;;;;; TREE VIEW
 
 (reg-event-db
-  :tree-view/clear-state
-  (sandbox)
-  (fn [db [_ loc path-vec]]
-    (update-in db [:cache] dissoc :tree-view)))
+ :tree-view/clear-state
+ (sandbox)
+ (fn [db [_ loc path-vec]]
+   (update-in db [:cache] dissoc :tree-view)))
 
 (reg-event-db
-  :tree-view/toggle-selection
-  (sandbox)
-  (fn [db [_ loc path-vec]]
-    (update-in db [:cache :tree-view :selection] toggle-into-set path-vec)))
+ :tree-view/toggle-selection
+ (sandbox)
+ (fn [db [_ loc path-vec]]
+   (update-in db [:cache :tree-view :selection] toggle-into-set path-vec)))
 
 (reg-event-fx
-  :tree-view/merge-new-columns
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc]]
-    (let [columns-to-add (map (partial clojure.string/join ".") (get-in db [:cache :tree-view :selection]))
-          model (get-in db [:service :model])]
-      {:db (-> db
-               (update-in [:query :select] #(apply conj % columns-to-add))
-               (assoc-in [:cache :tree-view :selection] #{}))
-       :dispatch [:im-tables.main/run-query loc]
-       :undo {:message [:div
-                        (str "Added " (count columns-to-add) " new column" (when (> (count columns-to-add) 1) "s"))
-                        (into [:div.table-history-detail] (map (fn [s] [:div (im-path/friendly model s)]) columns-to-add))]
-              :location loc}
-       })))
-
+ :tree-view/merge-new-columns
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc]]
+   (let [columns-to-add (map (partial clojure.string/join ".") (get-in db [:cache :tree-view :selection]))
+         model (get-in db [:service :model])]
+     {:db (-> db
+              (update-in [:query :select] #(apply conj % columns-to-add))
+              (assoc-in [:cache :tree-view :selection] #{}))
+      :dispatch [:im-tables.main/run-query loc]
+      :undo {:message [:div
+                       (str "Added " (count columns-to-add) " new column" (when (> (count columns-to-add) 1) "s"))
+                       (into [:div.table-history-detail] (map (fn [s] [:div (im-path/friendly model s)]) columns-to-add))]
+             :location loc}})))
 
 (defn coll-contains? [needle haystack] (some? (some #{needle} haystack)))
 (defn without [coll item] (filter (partial not= item) coll))
@@ -283,47 +275,50 @@
 ;;;;; Relationship Manager
 
 ; Copy the main query to our cache for editing
+
+
 (reg-event-db
-  :rel-manager/reset
-  (sandbox)
-  (fn [db [_ loc]]
-    (assoc-in db [:cache :rel-manager] (get db :query))))
+ :rel-manager/reset
+ (sandbox)
+ (fn [db [_ loc]]
+   (assoc-in db [:cache :rel-manager] (get db :query))))
 
 ; Copy the edited query from the cache back to the main query and run it
 (reg-event-fx
-  :rel-manager/apply-changes
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc]]
-    (let [pre-joins (set (get-in db [:query :joins]))
-          post-joins (set (get-in db [:cache :rel-manager :joins]))
-          added (not-empty (clojure.set/difference post-joins pre-joins))
-          removed (not-empty (clojure.set/difference pre-joins post-joins))
-          model (get-in db [:service :model])]
-      {:db (assoc db :query (get-in db [:cache :rel-manager]))
-       :dispatch [:im-tables.main/run-query loc]
-       :undo {:location loc
-              :message [:div
-                        (when added
-                          [:div
-                           [:div "Columns made mandatory"]
-                           (into [:div.table-history-detail]
-                                 (map (fn [c] [:div (im-path/friendly model c)]) added))])
-                        (when removed
-                          [:div
-                           [:div "Columns made optional"]
-                           (into [:div.table-history-detail]
-                                 (map (fn [c] [:div (im-path/friendly model c)]) removed))])]}})))
+ :rel-manager/apply-changes
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc]]
+   (let [pre-joins (set (get-in db [:query :joins]))
+         post-joins (set (get-in db [:cache :rel-manager :joins]))
+         added (not-empty (clojure.set/difference post-joins pre-joins))
+         removed (not-empty (clojure.set/difference pre-joins post-joins))
+         model (get-in db [:service :model])]
+     {:db (assoc db :query (get-in db [:cache :rel-manager]))
+      :dispatch [:im-tables.main/run-query loc]
+      :undo {:location loc
+             :message [:div
+                       (when added
+                         [:div
+                          [:div "Columns made mandatory"]
+                          (into [:div.table-history-detail]
+                                (map (fn [c] [:div (im-path/friendly model c)]) added))])
+                       (when removed
+                         [:div
+                          [:div "Columns made optional"]
+                          (into [:div.table-history-detail]
+                                (map (fn [c] [:div (im-path/friendly model c)]) removed))])]}})))
 
 (reg-event-db
-  :rel-manager/toggle-relationship
-  (sandbox)
-  (fn [db [_ loc view join?]]
-    (if join?
-      (update-in db [:cache :rel-manager :joins] conj view)
-      (update-in db [:cache :rel-manager :joins] without view))))
+ :rel-manager/toggle-relationship
+ (sandbox)
+ (fn [db [_ loc view join?]]
+   (if join?
+     (update-in db [:cache :rel-manager :joins] conj view)
+     (update-in db [:cache :rel-manager :joins] without view))))
 
 
 ;;;;; STYLE
+
 
 (defn swap
   "Given a collection, swap the positions of elements at index-a and index-b with eachother"
@@ -357,142 +352,140 @@
   (clojure.string/starts-with? string substring))
 
 (reg-event-db
-  :style/dragging-item
-  (sandbox)
-  (fn [db [_ loc view]]
-    (let [outer-join? (some? (some #{view} (get-in db [:query :joins])))]
-      (if outer-join?
+ :style/dragging-item
+ (sandbox)
+ (fn [db [_ loc view]]
+   (let [outer-join? (some? (some #{view} (get-in db [:query :joins])))]
+     (if outer-join?
         ; If the column (view) being dragged is part of an outer join then get the idx of the first occurance
-        (assoc-in db [:cache :dragging-item] (index (partial begins-with? view) (get-in db [:query :select])))
+       (assoc-in db [:cache :dragging-item] (index (partial begins-with? view) (get-in db [:query :select])))
         ; Otherwise, find an identical match
-        (assoc-in db [:cache :dragging-item] (index (partial = view) (get-in db [:query :select])))))))
+       (assoc-in db [:cache :dragging-item] (index (partial = view) (get-in db [:query :select])))))))
 
 (reg-event-db
-  :style/dragging-over
-  (sandbox)
-  (fn [db [_ loc view]]
-    (let [outer-join? (some? (some #{view} (get-in db [:query :joins])))]
-      (if outer-join?
+ :style/dragging-over
+ (sandbox)
+ (fn [db [_ loc view]]
+   (let [outer-join? (some? (some #{view} (get-in db [:query :joins])))]
+     (if outer-join?
         ; If the column (view) being dragged over is part of an outer join then get the idx of the first occurance
-        (assoc-in db [:cache :dragging-over] (index (partial begins-with? view) (get-in db [:query :select])))
+       (assoc-in db [:cache :dragging-over] (index (partial begins-with? view) (get-in db [:query :select])))
         ; Otherwise, find an identical match
-        (assoc-in db [:cache :dragging-over] (index (partial = view) (get-in db [:query :select])))))))
+       (assoc-in db [:cache :dragging-over] (index (partial = view) (get-in db [:query :select])))))))
 
 (reg-event-fx
-  :style/dragging-finished
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    (let [dragged-item (get-in db [:cache :dragging-item])
-          dragged-over (get-in db [:cache :dragging-over])]
-      (cond-> {:db (-> db
-                       (update-in [:query :select] move-nth dragged-item dragged-over)
-                       (update-in [:cache] dissoc :dragging-item :dragging-over))}
-              (not= dragged-item dragged-over) (assoc :dispatch-n
-                                                      [^:flush-dom [:show-overlay loc]
-                                                       [:im-tables.main/run-query loc]])))))
+ :style/dragging-finished
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [dragged-item (get-in db [:cache :dragging-item])
+         dragged-over (get-in db [:cache :dragging-over])]
+     (cond-> {:db (-> db
+                      (update-in [:query :select] move-nth dragged-item dragged-over)
+                      (update-in [:cache] dissoc :dragging-item :dragging-over))}
+       (not= dragged-item dragged-over) (assoc :dispatch-n
+                                               [^:flush-dom [:show-overlay loc]
+                                                [:im-tables.main/run-query loc]])))))
 
 ;;;;; MANIPULATE QUERY
 
 (reg-event-db
-  :main/save-column-summary
-  (sandbox)
-  (fn [db [_ loc view summary-response]]
-    (assoc-in db [:cache :column-summary view :response] summary-response)))
+ :main/save-column-summary
+ (sandbox)
+ (fn [db [_ loc view summary-response]]
+   (assoc-in db [:cache :column-summary view :response] summary-response)))
 
 (reg-event-fx
-  :main/summarize-column
-  (sandbox)
-  (fn [{db :db} [_ loc view]]
-    {:db db
-     :im-tables/im-operation {:on-success [:main/save-column-summary loc view]
-                              :op (partial fetch/unique-values
-                                           (get db :service)
-                                           (get db :query)
-                                           view
-                                           1000)}}))
+ :main/summarize-column
+ (sandbox)
+ (fn [{db :db} [_ loc view]]
+   {:db db
+    :im-tables/im-operation {:on-success [:main/save-column-summary loc view]
+                             :op (partial fetch/unique-values
+                                          (get db :service)
+                                          (get db :query)
+                                          view
+                                          1000)}}))
 
 (reg-event-fx
-  :main/apply-summary-filter
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc view]]
-    (let [model (get-in db [:service :model])]
-      (if-let [current-selection (keys (get-in db [:cache :column-summary view :selections]))]
-        {:db (update-in db [:query :where] conj {:path view
-                                                 :op "ONE OF"
-                                                 :values current-selection})
-         :dispatch [:im-tables.main/run-query loc]
-         :undo {:location loc
-                :message [:div
-                          [:div [:div
-                                 (str (im-path/friendly model view))
-                                 [:div "Must be one of:"]]]
-                          (into [:div.table-history-detail]
-                                (map (fn [v]
-                                       [:div v]) current-selection))
-                          ]}
-         }
-        {:db db}))))
+ :main/apply-summary-filter
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc view]]
+   (let [model (get-in db [:service :model])]
+     (if-let [current-selection (keys (get-in db [:cache :column-summary view :selections]))]
+       {:db (update-in db [:query :where] conj {:path view
+                                                :op "ONE OF"
+                                                :values current-selection})
+        :dispatch [:im-tables.main/run-query loc]
+        :undo {:location loc
+               :message [:div
+                         [:div [:div
+                                (str (im-path/friendly model view))
+                                [:div "Must be one of:"]]]
+                         (into [:div.table-history-detail]
+                               (map (fn [v]
+                                      [:div v]) current-selection))]}}
 
+       {:db db}))))
 
 (reg-event-fx
-  :main/apply-numerical-filter
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc view {:keys [from to]}]]
-    (let [model (get-in db [:service :model])]
-      (let [existing-constraints (get-in db [:query :where])
-            existing-from? (not-empty (filter (comp (partial = [view ">="]) (juxt :path :op)) existing-constraints))
-            existing-to? (not-empty (filter (comp (partial = [view "<="]) (juxt :path :op)) existing-constraints))]
-        {:db (update-in db [:query :where] #(cond->> %
-                                                     (and from existing-from?) (map (fn [{:keys [path op] :as c}] (if (and (= path view) (= op ">=")) (assoc c :value from) c)))
-                                                     (and from (not existing-from?)) (cons {:path view :op ">=" :value from})
-                                                     (and to existing-to?) (map (fn [{:keys [path op] :as c}] (if (and (= path view) (= op "<=")) (assoc c :value to) c)))
-                                                     (and to (not existing-to?)) (cons {:path view :op "<=" :value to})))
-         :dispatch [:im-tables.main/run-query loc]
-         :undo {:location loc
-                :message [:div
-                          (str (im-path/friendly model view))
-                          (cond-> [:div "Must be:"]
-                                  from (conj [:div.table-history-detail ">= " from])
-                                  to (conj [:div.table-history-detail "<= " to]))]}}))))
+ :main/apply-numerical-filter
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc view {:keys [from to]}]]
+   (let [model (get-in db [:service :model])]
+     (let [existing-constraints (get-in db [:query :where])
+           existing-from? (not-empty (filter (comp (partial = [view ">="]) (juxt :path :op)) existing-constraints))
+           existing-to? (not-empty (filter (comp (partial = [view "<="]) (juxt :path :op)) existing-constraints))]
+       {:db (update-in db [:query :where] #(cond->> %
+                                             (and from existing-from?) (map (fn [{:keys [path op] :as c}] (if (and (= path view) (= op ">=")) (assoc c :value from) c)))
+                                             (and from (not existing-from?)) (cons {:path view :op ">=" :value from})
+                                             (and to existing-to?) (map (fn [{:keys [path op] :as c}] (if (and (= path view) (= op "<=")) (assoc c :value to) c)))
+                                             (and to (not existing-to?)) (cons {:path view :op "<=" :value to})))
+        :dispatch [:im-tables.main/run-query loc]
+        :undo {:location loc
+               :message [:div
+                         (str (im-path/friendly model view))
+                         (cond-> [:div "Must be:"]
+                           from (conj [:div.table-history-detail ">= " from])
+                           to (conj [:div.table-history-detail "<= " to]))]}}))))
 
 (reg-event-fx
-  :main/remove-view
-  [(sandbox) (undoable)]
-  (fn [{db :db} [_ loc view]]
-    (let [path-is-join? (some? (some #{view} (get-in db [:query :joins])))
-          model (get-in db [:service :model])]
-      {:db (cond-> db
-                   (not path-is-join?) (update-in [:query :select] (partial remove (fn [v] (= v view))))
-                   path-is-join? (update-in [:query :select] (partial remove (fn [v] (starts-with? v view))))
-                   path-is-join? (update-in [:query :joins] (partial remove (fn [v] (= v view)))))
-       :dispatch [:im-tables.main/run-query loc]
-       :undo {:message [:div (str "Removed column")
-                        [:div.table-history-detail
-                         [:span (im-path/friendly model view)]]]
-              :location loc}})))
-
+ :main/remove-view
+ [(sandbox) (undoable)]
+ (fn [{db :db} [_ loc view]]
+   (let [path-is-join? (some? (some #{view} (get-in db [:query :joins])))
+         model (get-in db [:service :model])]
+     {:db (cond-> db
+            (not path-is-join?) (update-in [:query :select] (partial remove (fn [v] (= v view))))
+            path-is-join? (update-in [:query :select] (partial remove (fn [v] (starts-with? v view))))
+            path-is-join? (update-in [:query :joins] (partial remove (fn [v] (= v view)))))
+      :dispatch [:im-tables.main/run-query loc]
+      :undo {:message [:div (str "Removed column")
+                       [:div.table-history-detail
+                        [:span (im-path/friendly model view)]]]
+             :location loc}})))
 
 (reg-event-fx
-  :main/sort-by
-  (sandbox)
-  (fn [{db :db} [_ loc view]]
-    (let [view (join "." (drop 1 (split view ".")))
-          [current-sort-by] (get-in db [:query :orderBy])
-          update? (= view (:path current-sort-by))
-          current-direction (get-in db [:query :orderBy 0 :direction])]
-      {:db (if update?
-             (update-in db [:query :orderBy 0]
-                        assoc :direction (case current-direction
-                                           "ASC" "DESC"
-                                           "DESC" "ASC"))
-             (assoc-in db [:query :orderBy]
-                       [{:path view
-                         :direction "ASC"}]))
-       :dispatch [:im-tables.main/run-query loc]
-       })))
+ :main/sort-by
+ (sandbox)
+ (fn [{db :db} [_ loc view]]
+   (let [view (join "." (drop 1 (split view ".")))
+         [current-sort-by] (get-in db [:query :orderBy])
+         update? (= view (:path current-sort-by))
+         current-direction (get-in db [:query :orderBy 0 :direction])]
+     {:db (if update?
+            (update-in db [:query :orderBy 0]
+                       assoc :direction (case current-direction
+                                          "ASC" "DESC"
+                                          "DESC" "ASC"))
+            (assoc-in db [:query :orderBy]
+                      [{:path view
+                        :direction "ASC"}]))
+      :dispatch [:im-tables.main/run-query loc]})))
+
 
 
 ;;;;;; SUMMARY CACHING
+
 
 (defn summary-query [{:keys [class id summary-fields]}]
   {:from class
@@ -502,160 +495,155 @@
             :value id}]})
 
 (reg-event-db
-  :main/cache-item-summary
-  (sandbox)
-  (fn [db [_ loc response]]
-    (update-in db [:cache :item-details]
-               (fn [summary-map]
-                 (let [{:keys [objectId] :as r} (first (:results response))]
-                   (assoc summary-map objectId
-                                      {:value r
-                                       :views (:views response)
-                                       :column-headers (:columnHeaders response)}))))))
+ :main/cache-item-summary
+ (sandbox)
+ (fn [db [_ loc response]]
+   (update-in db [:cache :item-details]
+              (fn [summary-map]
+                (let [{:keys [objectId] :as r} (first (:results response))]
+                  (assoc summary-map objectId
+                         {:value r
+                          :views (:views response)
+                          :column-headers (:columnHeaders response)}))))))
 
 (reg-event-fx
-  :main/summarize-item
-  (sandbox)
-  (fn [{db :db} [_ loc {:keys [class id] :as item}]]
-    (cond-> {:db db}
-            (not (get-in db [:cache :item-details id]))
-            (assoc :im-tables/im-operation {:on-success
-                                            [:main/cache-item-summary loc]
-                                            :op
-                                            (partial fetch/records
-                                                     (get db :service)
-                                                     (summary-query
-                                                       (assoc item :summary-fields
-                                                                   (into [] (keys (get-in db [:service :model :classes (keyword class) :attributes]))))))}))))
+ :main/summarize-item
+ (sandbox)
+ (fn [{db :db} [_ loc {:keys [class id] :as item}]]
+   (cond-> {:db db}
+     (not (get-in db [:cache :item-details id]))
+     (assoc :im-tables/im-operation {:on-success
+                                     [:main/cache-item-summary loc]
+                                     :op
+                                     (partial fetch/records
+                                              (get db :service)
+                                              (summary-query
+                                               (assoc item :summary-fields
+                                                      (into [] (keys (get-in db [:service :model :classes (keyword class) :attributes]))))))}))))
 
 
 
 
 ;;;;;;;;;;;;;;
 
+
 (reg-event-db
-  :main/initial-query-response
-  (sandbox)
-  (fn [db [_ loc {:keys [start]} results]]
-    (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-          updated-results (assoc results :results new-results-map)]
-      (assoc db :response updated-results))))
+ :main/initial-query-response
+ (sandbox)
+ (fn [db [_ loc {:keys [start]} results]]
+   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
+         updated-results (assoc results :results new-results-map)]
+     (assoc db :response updated-results))))
 
 (reg-event-fx
-  :main/replace-query-response
-  (sandbox)
-  (fn [{db :db} [_ loc {:keys [start size]} results]]
+ :main/replace-query-response
+ (sandbox)
+ (fn [{db :db} [_ loc {:keys [start size]} results]]
     ;(println "no effect replace")
-    (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-          updated-results (assoc results :results new-results-map)]
-      {:db (assoc db :response updated-results)
+   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
+         updated-results (assoc results :results new-results-map)]
+     {:db (assoc db :response updated-results)
        ;:db         (assoc db :query-response results)
-       :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-                         (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
-       })))
+      :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
+                        (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
 
 (reg-event-fx
-  :main/merge-query-response
-  (sandbox)
-  (fn [{db :db} [_ loc {:keys [start size]} results]]
+ :main/merge-query-response
+ (sandbox)
+ (fn [{db :db} [_ loc {:keys [start size]} results]]
     ;(println "no effect merge")
-    (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-          updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
-      {:db (assoc db :response updated-results)
+   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
+         updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
+     {:db (assoc db :response updated-results)})))
        ;:db         (assoc db :query-response results)
        ;:dispatch-n (into [^:flush-dom [:hide-overlay loc]]
        ;                  (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
-       })))
+
 
 (reg-event-fx
-  :im-tables.main/run-query
-  (sandbox)
-  (let [previous-requests (atom {})]
-    (fn [{db :db} [_ loc merge?]]
-      (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
+ :im-tables.main/run-query
+ (sandbox)
+ (let [previous-requests (atom {})]
+   (fn [{db :db} [_ loc merge?]]
+     (let [{:keys [start limit] :as pagination} (get-in db [:settings :pagination])]
         ;(js/console.log "Running query: " loc (get db :query))
 
         ; Previous requests are stored in an atom containing a map. This is to prevent
         ; one table from cancelling a pending request belonging to another table.
 
         ; Close a previous request if it exists for this table's "location"
-        (some-> @previous-requests (get loc) close!)
+       (some-> @previous-requests (get loc) close!)
         ; Make a new request and replace the old request with the new one
-        (swap! previous-requests assoc loc (fetch/table-rows
-                                             (get db :service)
-                                             (get db :query)
-                                             {:start start
-                                              :size (* limit (get-in db [:settings :buffer]))}))
-        {:db (assoc-in db [:cache :column-summary] {})
-         :dispatch-n [^:flush-dom [:show-overlay loc]
-                      [:main/deconstruct loc]]
-         :im-tables/im-operation-chan {:on-success (if merge?
-                                                     ^:flush-dom [:main/merge-query-response loc pagination]
-                                                     ^:flush-dom [:main/replace-query-response loc pagination])
-                                       ; Hand the request atom off to the effect that takes from it
-                                       :channel (get @previous-requests loc)}}))))
-
-
-
-(reg-event-db
-  :main/save-decon-count
-  (sandbox)
-  (fn [db [_ loc path count]]
-    (assoc-in db [:query-parts path :count] count)))
-
-(reg-event-fx
-  :main/count-deconstruction
-  (sandbox)
-  (fn [{db :db} [_ loc path details]]
-    {:db db
-     :im-tables/im-operation {:on-success [:main/save-decon-count loc path]
-                              :op (partial fetch/row-count
+       (swap! previous-requests assoc loc (fetch/table-rows
                                            (get db :service)
-                                           (dissoc (get details :query) :joins))}}))
-
-(reg-event-fx
-  :main/deconstruct
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    (let [deconstructed-query (into {} (map vec (sort-by
-                                                  (fn [[p _]] (count (clojure.string/split p ".")))
-                                                  (partition 2
-                                                             (flatten
-                                                               (map seq (vals (query/deconstruct-by-class (get-in db [:service :model]) (get-in db [:query])))))))))]
-
-
-      {:db (assoc db :query-parts deconstructed-query)
-       :dispatch-n (into [] (map (fn [[part details]] [:main/count-deconstruction loc part details]) deconstructed-query))})))
-
-
-(reg-event-fx
-  :main/set-codegen-option
-  (sandbox)
-  (fn [{db :db} [_ loc option value run?]]
-    (cond-> {:db (assoc-in db [:settings :codegen option] value)}
-            run? (assoc :dispatch [:main/generate-code loc])
-            )))
-
-(reg-event-fx
-  :main/generate-code
-  (sandbox)
-  (let [fetch-atom (r/atom (chan))]
-    (fn [{db :db} [_ loc]]
-      ; Close any previous code generation requests
-      (swap! fetch-atom close!)
-      (let [{:keys [query service]} db
-            lang (get-in db [:settings :codegen :lang])
-            new-request (fetch/code service (:model service) {:query query :lang lang})]
-        ; Store the new request
-        (reset! fetch-atom new-request)
-        ; Clear the old code
-        {:db (-> db (assoc-in [:codegen :code] nil))
-         :im-tables/im-operation-chan
-         {:on-success [:main/save-codegen loc lang]
-          :channel new-request}}))))
+                                           (get db :query)
+                                           {:start start
+                                            :size (* limit (get-in db [:settings :buffer]))}))
+       {:db (assoc-in db [:cache :column-summary] {})
+        :dispatch-n [^:flush-dom [:show-overlay loc]
+                     [:main/deconstruct loc]]
+        :im-tables/im-operation-chan {:on-success (if merge?
+                                                    ^:flush-dom [:main/merge-query-response loc pagination]
+                                                    ^:flush-dom [:main/replace-query-response loc pagination])
+                                       ; Hand the request atom off to the effect that takes from it
+                                      :channel (get @previous-requests loc)}}))))
 
 (reg-event-db
-  :main/save-codegen
-  (sandbox)
-  (fn [db [_ loc lang response]]
-    (update db :codegen assoc :code response :lang lang)))
+ :main/save-decon-count
+ (sandbox)
+ (fn [db [_ loc path count]]
+   (assoc-in db [:query-parts path :count] count)))
+
+(reg-event-fx
+ :main/count-deconstruction
+ (sandbox)
+ (fn [{db :db} [_ loc path details]]
+   {:db db
+    :im-tables/im-operation {:on-success [:main/save-decon-count loc path]
+                             :op (partial fetch/row-count
+                                          (get db :service)
+                                          (dissoc (get details :query) :joins))}}))
+
+(reg-event-fx
+ :main/deconstruct
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [deconstructed-query (into {} (map vec (sort-by
+                                                (fn [[p _]] (count (clojure.string/split p ".")))
+                                                (partition 2
+                                                           (flatten
+                                                            (map seq (vals (query/deconstruct-by-class (get-in db [:service :model]) (get-in db [:query])))))))))]
+
+     {:db (assoc db :query-parts deconstructed-query)
+      :dispatch-n (into [] (map (fn [[part details]] [:main/count-deconstruction loc part details]) deconstructed-query))})))
+
+(reg-event-fx
+ :main/set-codegen-option
+ (sandbox)
+ (fn [{db :db} [_ loc option value run?]]
+   (cond-> {:db (assoc-in db [:settings :codegen option] value)}
+     run? (assoc :dispatch [:main/generate-code loc]))))
+
+(reg-event-fx
+ :main/generate-code
+ (sandbox)
+ (let [fetch-atom (r/atom (chan))]
+   (fn [{db :db} [_ loc]]
+      ; Close any previous code generation requests
+     (swap! fetch-atom close!)
+     (let [{:keys [query service]} db
+           lang (get-in db [:settings :codegen :lang])
+           new-request (fetch/code service (:model service) {:query query :lang lang})]
+        ; Store the new request
+       (reset! fetch-atom new-request)
+        ; Clear the old code
+       {:db (-> db (assoc-in [:codegen :code] nil))
+        :im-tables/im-operation-chan
+        {:on-success [:main/save-codegen loc lang]
+         :channel new-request}}))))
+
+(reg-event-db
+ :main/save-codegen
+ (sandbox)
+ (fn [db [_ loc lang response]]
+   (update db :codegen assoc :code response :lang lang)))

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -31,15 +31,17 @@
   [chans]
   (go-loop [coll '()
             chans (reverse chans)]
-           (if (seq chans)
-             (recur (conj coll (<! (first chans)))
-                    (rest chans))
-             coll)))
+    (if (seq chans)
+      (recur (conj coll (<! (first chans)))
+             (rest chans))
+      coll)))
 
 
 
 ; TODO - WIP - If assets are missing when a component is mounted then
 ; fetch them and/or run necessary queries
+
+
 (reg-event-fx :im-tables/load
               (sandbox)
               (fn [{db :db} [_ loc {:keys [query service location response settings] :as args}]]
@@ -58,12 +60,12 @@
 
           (go (let [[model summary-fields]
                     (<!
-                      (<<!
-                        (-> []
+                     (<<!
+                      (-> []
                             ; Get model from view arguments, or app-db, or remotely
-                            (conj (go (or (:model service) (-> db :service :model) (<! (fetch/model service)))))
+                          (conj (go (or (:model service) (-> db :service :model) (<! (fetch/model service)))))
                             ; Get summary fields from view arguments, or app-db, or remotely
-                            (conj (go (or (:summary-fields service) (-> db :service :summary-fields) (<! (fetch/summary-fields service))))))))]
+                          (conj (go (or (:summary-fields service) (-> db :service :summary-fields) (<! (fetch/summary-fields service))))))))]
                 ; Now we have a service with all of the needed components
                 (let [complete-service (assoc service :model model :summary-fields summary-fields)]
                   (dispatch [:im-tables/store-setup loc {:service complete-service
@@ -83,51 +85,50 @@
                                                  :channel (fetch/table-rows service query {:start start
                                                                                            :size (* limit buffer)})}})))
 
-
 (reg-event-db
-  :initialize-db
-  (fn [_] db/default-db))
+ :initialize-db
+ (fn [_] db/default-db))
 
 ; Fetch an anonymous token for a give
 (reg-event-fx
-  :imt.auth/fetch-anonymous-token
-  (sandbox)
-  (fn [{db :db} [_ loc service]]
-    {:db db
-     :im-tables/im-operation {:on-success [:imt.auth/store-token loc]
-                              :op (partial fetch/session service)}}))
+ :imt.auth/fetch-anonymous-token
+ (sandbox)
+ (fn [{db :db} [_ loc service]]
+   {:db db
+    :im-tables/im-operation {:on-success [:imt.auth/store-token loc]
+                             :op (partial fetch/session service)}}))
 
 ; Store an auth token for a given mine
 (reg-event-db
-  :imt.auth/store-token
-  (sandbox)
-  (fn [db [_ loc token]]
-    (assoc-in db [:service :token] token)))
+ :imt.auth/store-token
+ (sandbox)
+ (fn [db [_ loc token]]
+   (assoc-in db [:service :token] token)))
 
 (reg-event-fx
-  :fetch-asset
-  (fn [{db :db} [_ im-op]]
-    {:db db
-     :im-tables/im-operation im-op}))
+ :fetch-asset
+ (fn [{db :db} [_ im-op]]
+   {:db db
+    :im-tables/im-operation im-op}))
 
 (reg-event-fx
-  :imt.main/fetch-assets
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    {:db db
-     :dispatch-n [[:fetch-asset {:on-success [:imt.main/save-summary-fields loc]
-                                 :op (partial fetch/summary-fields (get db :service))}]
-                  [:fetch-asset {:on-success [:imt.main/save-model loc]
-                                 :op (partial fetch/model (get db :service))}]]}))
+ :imt.main/fetch-assets
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   {:db db
+    :dispatch-n [[:fetch-asset {:on-success [:imt.main/save-summary-fields loc]
+                                :op (partial fetch/summary-fields (get db :service))}]
+                 [:fetch-asset {:on-success [:imt.main/save-model loc]
+                                :op (partial fetch/model (get db :service))}]]}))
 
 (reg-event-db
-  :imt.main/save-model
-  (sandbox)
-  (fn [db [_ loc model]]
-    (assoc-in db [:service :model] model)))
+ :imt.main/save-model
+ (sandbox)
+ (fn [db [_ loc model]]
+   (assoc-in db [:service :model] model)))
 
 (reg-event-db
-  :imt.main/save-summary-fields
-  (sandbox)
-  (fn [db [_ loc summary-fields]]
-    (assoc-in db [:assets :summary-fields] summary-fields)))
+ :imt.main/save-summary-fields
+ (sandbox)
+ (fn [db [_ loc summary-fields]]
+   (assoc-in db [:assets :summary-fields] summary-fields)))

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -85,7 +85,7 @@
                           (get db :service)
                           (get db :query)
                           {:format (:file-type file-type)})}
-     :db db}))
+    :db db}))
 
 (reg-event-fx
  :exporttable/run-fasta-query

--- a/src/im_tables/events/pagination.cljs
+++ b/src/im_tables/events/pagination.cljs
@@ -3,50 +3,48 @@
             [im-tables.interceptors :refer [sandbox]]))
 
 (reg-event-fx
-  :imt.pagination/check-for-results
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    (let [{:keys [start limit] :as p} (get-in db [:settings :pagination])
-          fetch-more? (not-every? (fn [n] (contains? (get-in db [:response :results]) n)) (range start (+ start limit)))]
-      (cond-> {:db db}
-              fetch-more? (assoc :dispatch [:im-tables.main/run-query loc true])))))
-
-
+ :imt.pagination/check-for-results
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [{:keys [start limit] :as p} (get-in db [:settings :pagination])
+         fetch-more? (not-every? (fn [n] (contains? (get-in db [:response :results]) n)) (range start (+ start limit)))]
+     (cond-> {:db db}
+       fetch-more? (assoc :dispatch [:im-tables.main/run-query loc true])))))
 
 (reg-event-fx
-  :imt.settings/update-pagination-inc
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    {:db       (update-in db [:settings :pagination :start] + (get-in db [:settings :pagination :limit]))
-     :dispatch [:imt.pagination/check-for-results loc]}))
+ :imt.settings/update-pagination-inc
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   {:db       (update-in db [:settings :pagination :start] + (get-in db [:settings :pagination :limit]))
+    :dispatch [:imt.pagination/check-for-results loc]}))
 
 (reg-event-fx
-  :imt.settings/update-pagination-dec
-  (sandbox)
-  (fn [{db :db} [_ loc]]
+ :imt.settings/update-pagination-dec
+ (sandbox)
+ (fn [{db :db} [_ loc]]
     ; Make sure that never dec to a negative number
     ; (This could happen if a user goes to page 2 with a limit of 10, changes limit to 20, then decs (-10)
-    {:db (update-in db [:settings :pagination :start] (comp (partial max 0) #(- % %2)) (get-in db [:settings :pagination :limit]))
-     :dispatch [:imt.pagination/check-for-results loc]}))
+   {:db (update-in db [:settings :pagination :start] (comp (partial max 0) #(- % %2)) (get-in db [:settings :pagination :limit]))
+    :dispatch [:imt.pagination/check-for-results loc]}))
 
 (reg-event-fx
-  :imt.settings/update-pagination-fulldec
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    {:db       (assoc-in db [:settings :pagination :start] 0)
-     :dispatch [:imt.pagination/check-for-results loc]}))
+ :imt.settings/update-pagination-fulldec
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   {:db       (assoc-in db [:settings :pagination :start] 0)
+    :dispatch [:imt.pagination/check-for-results loc]}))
 
 (reg-event-fx
-  :imt.settings/update-pagination-fullinc
-  (sandbox)
-  (fn [{db :db} [_ loc]]
-    (let [total (get-in db [:response :iTotalRecords])]
-      {:db       (assoc-in db [:settings :pagination :start] (- total (mod total 10)))
-       :dispatch [:imt.pagination/check-for-results loc]})))
+ :imt.settings/update-pagination-fullinc
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [total (get-in db [:response :iTotalRecords])]
+     {:db       (assoc-in db [:settings :pagination :start] (- total (mod total 10)))
+      :dispatch [:imt.pagination/check-for-results loc]})))
 
 (reg-event-fx
-  :imt.settings/update-pagination-limit
-  (sandbox)
-  (fn [{db :db} [_ loc limit]]
-    {:db       (assoc-in db [:settings :pagination :limit] limit)
-     :dispatch [:imt.pagination/check-for-results loc]}))
+ :imt.settings/update-pagination-limit
+ (sandbox)
+ (fn [{db :db} [_ loc limit]]
+   {:db       (assoc-in db [:settings :pagination :limit] limit)
+    :dispatch [:imt.pagination/check-for-results loc]}))

--- a/src/im_tables/interceptors.cljs
+++ b/src/im_tables/interceptors.cljs
@@ -9,25 +9,25 @@
   (dispatch [:some-event some-data [:my :sandboxed :location])"
   []
   (->interceptor
-    :id :sandbox
-    :before (fn [context]
+   :id :sandbox
+   :before (fn [context]
               ;(.log js/console "before" context)
-              (if-let [path (second (get-in context [:coeffects :event]))]
-                (do
+             (if-let [path (second (get-in context [:coeffects :event]))]
+               (do
                   ;(println "before found path" path)
 
-                  (update context :coeffects assoc
-                          :old-db (get-in context [:coeffects :db])
-                          :db (get-in context (concat [:coeffects :db] path))))
-                context))
-    :after (fn [context]
-             #_(.log js/console "after" (if-let [path (second (get-in context [:coeffects :event]))]
-                                        (let [old-db (get-in context [:coeffects :old-db])
-                                              new-db (get-in context [:effects :db])]
-                                          (assoc-in context [:effects :db] (assoc-in old-db path new-db)))
-                                        context))
-             (if-let [path (second (get-in context [:coeffects :event]))]
-               (let [old-db (get-in context [:coeffects :old-db])
-                     new-db (get-in context [:effects :db])]
-                 (assoc-in context [:effects :db] (assoc-in old-db path new-db)))
-               context))))
+                 (update context :coeffects assoc
+                         :old-db (get-in context [:coeffects :db])
+                         :db (get-in context (concat [:coeffects :db] path))))
+               context))
+   :after (fn [context]
+            #_(.log js/console "after" (if-let [path (second (get-in context [:coeffects :event]))]
+                                         (let [old-db (get-in context [:coeffects :old-db])
+                                               new-db (get-in context [:effects :db])]
+                                           (assoc-in context [:effects :db] (assoc-in old-db path new-db)))
+                                         context))
+            (if-let [path (second (get-in context [:coeffects :event]))]
+              (let [old-db (get-in context [:coeffects :old-db])
+                    new-db (get-in context [:effects :db])]
+                (assoc-in context [:effects :db] (assoc-in old-db path new-db)))
+              context))))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -8,99 +8,99 @@
   (reduce conj (or path []) remainder-vec))
 
 (reg-sub
-  :main/query-response
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:response]))))
+ :main/query-response
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:response]))))
 
 (reg-sub
-  :main/query
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:query]))))
+ :main/query
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:query]))))
 
 (reg-sub
-  :main/temp-query
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:temp-query]))))
+ :main/temp-query
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:temp-query]))))
 
 (reg-sub
-  :main/query-parts
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:query-parts]))))
+ :main/query-parts
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:query-parts]))))
 
 (reg-sub
-  :style/overlay?
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :overlay?]))))
+ :style/overlay?
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :overlay?]))))
 
 (reg-sub
-  :summary/item-details
-  (fn [db [_ loc id]]
-    (get-in db (glue loc [:cache :item-details id]))))
+ :summary/item-details
+ (fn [db [_ loc id]]
+   (get-in db (glue loc [:cache :item-details id]))))
 
 (reg-sub
-  :style/dragging-item
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :dragging-item]))))
+ :style/dragging-item
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :dragging-item]))))
 
 (reg-sub
-  :style/dragging-over
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :dragging-over]))))
+ :style/dragging-over
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :dragging-over]))))
 
 (reg-sub
-  :settings/pagination
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:settings :pagination]))))
+ :settings/pagination
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:settings :pagination]))))
 
 (reg-sub
-  :settings/data-out
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:settings :data-out]))))
+ :settings/data-out
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:settings :data-out]))))
 
 (reg-sub
-  :settings/settings
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:settings]))))
+ :settings/settings
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:settings]))))
 
 (reg-sub
-  :summaries/column-summaries
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :column-summary]))))
+ :summaries/column-summaries
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :column-summary]))))
 
 (reg-sub
-  :selection/selections
-  (fn [db [_ prefix view]]
-    (get-in db (glue prefix [:cache :column-summary view :selections]))))
+ :selection/selections
+ (fn [db [_ prefix view]]
+   (get-in db (glue prefix [:cache :column-summary view :selections]))))
 
 (reg-sub
-  :selection/response
-  (fn [db [_ prefix view]]
-    (get-in db (glue prefix [:cache :column-summary view :response]))))
+ :selection/response
+ (fn [db [_ prefix view]]
+   (get-in db (glue prefix [:cache :column-summary view :response]))))
 
 (reg-sub
-  :selection/text-filter
-  (fn [db [_ prefix view]]
-    (get-in db (glue prefix [:cache :column-summary view :filters :text]))))
+ :selection/text-filter
+ (fn [db [_ prefix view]]
+   (get-in db (glue prefix [:cache :column-summary view :filters :text]))))
 
 (reg-sub
-  :assets/model
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:service :model]))))
+ :assets/model
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:service :model]))))
 
 (reg-sub
-  :assets/service
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:service]))))
+ :assets/service
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:service]))))
 
 (reg-sub
-  :tree-view/selection
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :tree-view :selection]))))
+ :tree-view/selection
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :tree-view :selection]))))
 
 (reg-sub
-  :modal
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:cache :modal]))))
+ :modal
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :modal]))))
 
 (defn head-contains?
   "True if a collection's head contains all elements of another collection (sub-coll)
@@ -135,14 +135,14 @@
             (filter (partial head-missing? starts-with) (drop (count leading) string-coll)))))
 
 (reg-sub
-  :query-response/views
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:response :views]))))
+ :query-response/views
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:response :views]))))
 
 (reg-sub
-  :query/joins
-  (fn [db [_ prefix]]
-    (get-in db (glue prefix [:query :joins]))))
+ :query/joins
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:query :joins]))))
 
 ; The following two subscriptions do two things to support outer joins, resulting in:
 ;     Gene.secondaryIdentifier Gene.publications.year Gene.symbol Gene.publications.title
@@ -155,26 +155,26 @@
 
 ; First move any views that are part of outer joins next to eachother:
 (reg-sub
-  :query-response/views-sorted-by-joins
-  (fn [[_ loc]]
-    [(subscribe [:query-response/views loc])
-     (subscribe [:query/joins loc])])
-  (fn [[views joins]]
-    (reduce (fn [total next] (group-by-starts-with total next)) views joins)))
+ :query-response/views-sorted-by-joins
+ (fn [[_ loc]]
+   [(subscribe [:query-response/views loc])
+    (subscribe [:query/joins loc])])
+ (fn [[views joins]]
+   (reduce (fn [total next] (group-by-starts-with total next)) views joins)))
 
 ; ...then replace all views that are part of outer joins with the name of the outer joins:
 (reg-sub
-  :query-response/views-collapsed-by-joins
-  (fn [[_ loc]]
-    [(subscribe [:query-response/views-sorted-by-joins loc])
-     (subscribe [:query/joins loc])])
-  (fn [[views joins]]
-    (reduce (fn [total next] (replace-join-views total next)) views joins)))
+ :query-response/views-collapsed-by-joins
+ (fn [[_ loc]]
+   [(subscribe [:query-response/views-sorted-by-joins loc])
+    (subscribe [:query/joins loc])])
+ (fn [[views joins]]
+   (reduce (fn [total next] (replace-join-views total next)) views joins)))
 
 (reg-sub
-  :rel-manager/query
-  (fn [db [_ loc]]
-    (get-in db (glue loc [:cache :rel-manager]))))
+ :rel-manager/query
+ (fn [db [_ loc]]
+   (get-in db (glue loc [:cache :rel-manager]))))
 
 ;;;;;;;;;;;;;;;; Code generation
 
@@ -182,77 +182,77 @@
   (string/join "\n"
                (-> []
                    (cond->
-                     (and html? comments?) (conj "<!-- The Element we will target -->")
-                     html? (conj "<div id=\"some-elem\"></div>\n")
-                     (and html? comments?) (conj "<!-- The imtables source -->")
-                     html? (conj (str "<script src=\"" cdn "/js/intermine/im-tables/2.0.0-beta/imtables.js\" charset=\"UTF8\"></script>"))
-                     html? (conj (str "<link href=\"" cdn "/js/intermine/im-tables/2.0.0-beta/main.sandboxed.css\" rel=\"stylesheet\">\n"))
-                     html? (conj "<script>")
-                     
-                     (and (not html?) comments?) (conj "/* Install from npm: npm install imtables\n * This snippet assumes the presence on the page of an element like:\n * <div id=\"some-elem\"></div>\n */")
-                     (not html?) (conj "var imtables = require(\"imtables\");\n"))
+                    (and html? comments?) (conj "<!-- The Element we will target -->")
+                    html? (conj "<div id=\"some-elem\"></div>\n")
+                    (and html? comments?) (conj "<!-- The imtables source -->")
+                    html? (conj (str "<script src=\"" cdn "/js/intermine/im-tables/2.0.0-beta/imtables.js\" charset=\"UTF8\"></script>"))
+                    html? (conj (str "<link href=\"" cdn "/js/intermine/im-tables/2.0.0-beta/main.sandboxed.css\" rel=\"stylesheet\">\n"))
+                    html? (conj "<script>")
+
+                    (and (not html?) comments?) (conj "/* Install from npm: npm install imtables\n * This snippet assumes the presence on the page of an element like:\n * <div id=\"some-elem\"></div>\n */")
+                    (not html?) (conj "var imtables = require(\"imtables\");\n"))
                    (conj "var selector = \"#some-elem\";\n")
                    (conj (str "var service = " (js/JSON.stringify
-                                                 (clj->js (-> service
-                                                              (select-keys [:root :token])
-                                                              (update :root scrub-url))) nil 2) "\n"))
+                                                (clj->js (-> service
+                                                             (select-keys [:root :token])
+                                                             (update :root scrub-url))) nil 2) "\n"))
                    (conj (str "var query = " (js/JSON.stringify (clj->js query) nil 2) "\n"))
                    (conj (str "imtables.loadTable(\n  selector, // Can also be an element, or a jQuery object.\n  {\"start\":0,\"size\":25}, // May be null\n  {service: service, query: query} // May be an imjs.Query\n).then(\n  function (table) { console.log('Table loaded', table); },\n  function (error) { console.error('Could not load table', error); }\n);"))
                    (cond->
-                     html? (conj "</script>")))))
+                    html? (conj "</script>")))))
 
 (defn remove-java-comments [s]
   (clojure.string/replace s #"/\*([\S\s]*?)\*/" ""))
 
 (defn octo-comment? [s]
   (or
-    (clojure.string/starts-with? s "# ")
-    (every? true? (map (partial = "#") s))))
+   (clojure.string/starts-with? s "# ")
+   (every? true? (map (partial = "#") s))))
 
 (def not-octo-comment? (complement octo-comment?))
 
 (defn remove-octothorpe-comments [s]
   (let [lines (clojure.string/split-lines s)]
     (clojure.string/replace
-      (->> lines
-           (map (fn [line] (if (octo-comment? line) "\n" line)))
-           (clojure.string/join "\n"))
-      #"\n\n\n+"
-      "\n\n")))
+     (->> lines
+          (map (fn [line] (if (octo-comment? line) "\n" line)))
+          (clojure.string/join "\n"))
+     #"\n\n\n+"
+     "\n\n")))
 
 (defn format-code [{:keys [lang code comments? html? query service cdn] :as options}]
   (cond
     (= "js" lang) (when (and query service) (generate-javascript options))
     (= "java" lang) (cond-> code (not comments?) remove-java-comments)
     (or
-      (= "rb" lang)
-      (= "py" lang)
-      (= "pl" lang)) (cond-> code (not comments?) remove-octothorpe-comments)
+     (= "rb" lang)
+     (= "py" lang)
+     (= "pl" lang)) (cond-> code (not comments?) remove-octothorpe-comments)
     :else ""))
 
 (reg-sub
-  :codegen/code
-  (fn [db [_ loc]]
-    (get-in db (glue loc [:codegen :code]))))
+ :codegen/code
+ (fn [db [_ loc]]
+   (get-in db (glue loc [:codegen :code]))))
 
 (reg-sub
-  :codegen/options
-  (fn [db [_ loc]]
-    (get-in db (glue loc [:settings :codegen]))))
+ :codegen/options
+ (fn [db [_ loc]]
+   (get-in db (glue loc [:settings :codegen]))))
 
 (reg-sub
-  :codegen/formatted-code
-  (fn [db [_ loc]]
-    (let [{:keys [html? comments? lang]} (get-in db (glue loc [:settings :codegen]))
-          code (get-in db (glue loc [:codegen :code]))
-          cdn (get-in db (glue loc [:settings :cdn]))
-          {:keys [query service]} (get-in db (glue loc nil))]
-      (when code
-        (format-code {:lang lang
-                      :code code
-                      :comments? comments?
-                      :html? html?
-                      :query query
-                      :service service
-                      :cdn cdn})))))
+ :codegen/formatted-code
+ (fn [db [_ loc]]
+   (let [{:keys [html? comments? lang]} (get-in db (glue loc [:settings :codegen]))
+         code (get-in db (glue loc [:codegen :code]))
+         cdn (get-in db (glue loc [:settings :cdn]))
+         {:keys [query service]} (get-in db (glue loc nil))]
+     (when code
+       (format-code {:lang lang
+                     :code code
+                     :comments? comments?
+                     :html? html?
+                     :query query
+                     :service service
+                     :cdn cdn})))))
 

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -36,6 +36,8 @@
 ; This function is used for testing purposes.
 ; When using im-tables in real life, you could call the view like so:
 ; [im-tables.views.core/main {:location ... :service ... :query ...}]
+
+
 (defn main-panel []
   ; Increase these range to produce N number of tables on the same page
   ; (useful for stress testing)
@@ -43,22 +45,22 @@
         reboot-tables-fn (fn [] (dotimes [n number-of-tables]
                                   (dispatch [:im-tables/load [:test :location n] some-im-tables-config])))]
     (r/create-class
-      {:component-did-mount reboot-tables-fn
-       :reagent-render (let [show? (r/atom true)]
-                         (fn []
-                           [:div.container-fluid
-                            [:div.container
-                             [:div.panel.panel-info
-                              [:div.panel-heading (str "Global Test Controls for " number-of-tables " tables")]
-                              [:div.panel-body
-                               [:div.btn-toolbar
-                                [:div.btn-group
-                                 [:button.btn.btn-default {:on-click reboot-tables-fn}
-                                  "Reboot Tables"]]
-                                [:div.btn-group
-                                 [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
-                                  (if @show? "Unmount Tables" "Mount Tables")]]]]]]
-                            (when @show?
-                              (into [:div]
-                                    (->> (range 0 number-of-tables)
-                                         (map (fn [n] [main-view/main [:test :location n]])))))]))})))
+     {:component-did-mount reboot-tables-fn
+      :reagent-render (let [show? (r/atom true)]
+                        (fn []
+                          [:div.container-fluid
+                           [:div.container
+                            [:div.panel.panel-info
+                             [:div.panel-heading (str "Global Test Controls for " number-of-tables " tables")]
+                             [:div.panel-body
+                              [:div.btn-toolbar
+                               [:div.btn-group
+                                [:button.btn.btn-default {:on-click reboot-tables-fn}
+                                 "Reboot Tables"]]
+                               [:div.btn-group
+                                [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
+                                 (if @show? "Unmount Tables" "Mount Tables")]]]]]]
+                           (when @show?
+                             (into [:div]
+                                   (->> (range 0 number-of-tables)
+                                        (map (fn [n] [main-view/main [:test :location n]])))))]))})))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -25,17 +25,16 @@
   (fn [loc {:keys [header body footer extra-class]}]
     [:div.im-modal
      {:on-mouse-down (fn [e]
-                  (dispatch [:prep-modal loc nil]))}
+                       (dispatch [:prep-modal loc nil]))}
      [:div.im-modal-content
       {:class extra-class
        :on-mouse-down (fn [e]
-                   (ocall e :stopPropagation))}
+                        (ocall e :stopPropagation))}
       [:div.modal-dialog.
        [:div.modal-content
         [:div.modal-header header]
         [:div.modal-body body]
         [:div.modal-footer footer]]]]]))
-
 
 (defn constraint-has-path? [view constraint]
   (= view (:path constraint)))
@@ -51,63 +50,63 @@
         collapsed-views (subscribe [:query-response/views-collapsed-by-joins location])
         views (subscribe [:query-response/views])]
     (reagent/create-class
-      {:reagent-render
-       (fn [location]
+     {:reagent-render
+      (fn [location]
          ; The query results are stored in a map with the result index as the key.
          ; In other words, we're not using a vector! To generate a speedy preview,
          ; get the first n results to be shown as a simple table:
          ; (get results 0), (get results 1), (get results 2) ... (get results limit)
-         (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
-           [:div.im-table.relative
+        (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
+          [:div.im-table.relative
             ; When the mouse touches the table, set the flag to render the actual React components
-            {:on-mouse-over (fn []
-                              (when @static?
-                                (dispatch [:main/deconstruct location])
-                                (doseq [event (map (fn [view] [:main/summarize-column location view]) @views)]
-                                  (dispatch event))
-                                (reset! static? false)))}
+           {:on-mouse-over (fn []
+                             (when @static?
+                               (dispatch [:main/deconstruct location])
+                               (doseq [event (map (fn [view] [:main/summarize-column location view]) @views)]
+                                 (dispatch event))
+                               (reset! static? false)))}
 
-            (if @static?
+           (if @static?
               ; If static (optimised) then only show an HTML representations of the React components
-              [:div
+             [:div
                ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
-               [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
-               [:table.table.table-condensed.table-bordered.table-striped
+              [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
+              [:table.table.table-condensed.table-bordered.table-striped
                 ; Good old static (fast) html table:
-                [:thead
-                 (into [:tr]
-                       (->> @collapsed-views
-                            (map-indexed (fn [idx h]
-                                           (let [display-name (when (and @model h) (impath/display-name @model h))
-                                                 active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
+               [:thead
+                (into [:tr]
+                      (->> @collapsed-views
+                           (map-indexed (fn [idx h]
+                                          (let [display-name (when (and @model h) (impath/display-name @model h))
+                                                active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
                                              ; This is a simple HTML representation of
                                              ; im-tables.views.table.head.controls/toolbar
                                              ; If you modify this form or the one in the toolbar, please remember to modify both
                                              ; or they won't look the same when the table is activated
-                                             [:th
-                                              [:div.summary-toolbar
-                                               [:i.fa.fa-sort.sort-icon]
-                                               [:i.fa.fa-times.remove-icon]
-                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon
-                                                {:class (when active-filters "active-filter")}]
-                                               [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
-                                              [:div
-                                               [:div (last (drop-last display-name))]
-                                               [:div (last display-name)]]])))))]
-                (into [:tbody] (map (fn [row]
-                                      (into [:tr] (map (fn [cell]
-                                                         [:td
-                                                          (if-let [value (:value cell)]
-                                                            [:a value]
-                                                            [:a.no-value "NO VALUE"])]) row))) preview-rows))]]
+                                            [:th
+                                             [:div.summary-toolbar
+                                              [:i.fa.fa-sort.sort-icon]
+                                              [:i.fa.fa-times.remove-icon]
+                                              [:i.fa.fa-filter.dropdown-toggle.filter-icon
+                                               {:class (when active-filters "active-filter")}]
+                                              [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
+                                             [:div
+                                              [:div (last (drop-last display-name))]
+                                              [:div (last display-name)]]])))))]
+               (into [:tbody] (map (fn [row]
+                                     (into [:tr] (map (fn [cell]
+                                                        [:td
+                                                         (if-let [value (:value cell)]
+                                                           [:a value]
+                                                           [:a.no-value "NO VALUE"])]) row))) preview-rows))]]
               ; Otherwise show the interactive React components
-              [:div
-               [dashboard/main location @response @pagination]
-               [table/main location @response @pagination]])
+             [:div
+              [dashboard/main location @response @pagination]
+              [table/main location @response @pagination]])
 
             ; Only show the modal when the modal subscription has a value
-            (when @modal-markup [custom-modal location @modal-markup])
+           (when @modal-markup [custom-modal location @modal-markup])]))})))
 
             ; Cover the app whenever it's thinking
             ;[table-thinking @overlay?]
-            ]))})))
+

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -48,7 +48,8 @@
         static? (reagent/atom true)
         model (subscribe [:assets/model location])
         query (subscribe [:main/query location])
-        collapsed-views (subscribe [:query-response/views-collapsed-by-joins location])]
+        collapsed-views (subscribe [:query-response/views-collapsed-by-joins location])
+        views (subscribe [:query-response/views])]
     (reagent/create-class
       {:reagent-render
        (fn [location]
@@ -59,7 +60,12 @@
          (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
            [:div.im-table.relative
             ; When the mouse touches the table, set the flag to render the actual React components
-            {:on-mouse-over (fn [] (reset! static? false))}
+            {:on-mouse-over (fn []
+                              (when @static?
+                                (dispatch [:main/deconstruct location])
+                                (doseq [event (map (fn [view] [:main/summarize-column location view]) @views)]
+                                  (dispatch event))
+                                (reset! static? false)))}
 
             (if @static?
               ; If static (optimised) then only show an HTML representations of the React components

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -6,7 +6,6 @@
             [imcljs.path :as path :refer [walk class]]
             [im-tables.components.bootstrap :refer [modal]]))
 
-
 (defn check-if-good
   "checks if certain formats are suitable for export given the data in the table
     Right now this is explicitly for FASTA, which requires a gene or protein.
@@ -14,13 +13,12 @@
     with the new possible format appended to the end. "
   [good-formats model-parts suitable-for format]
   (let [model-bits (set (keys model-parts))]
-  (distinct
-   (reduce
-    (fn [suitable-bit]
-     (if (contains? model-bits (name suitable-bit))
-       (conj good-formats format)
-       good-formats)
-      ) suitable-for))))
+    (distinct
+     (reduce
+      (fn [suitable-bit]
+        (if (contains? model-bits (name suitable-bit))
+          (conj good-formats format)
+          good-formats)) suitable-for))))
 
 (defn modal-body
   "creates the dropdown to allow users to select their preferred format"
@@ -30,12 +28,11 @@
           model-parts (subscribe [:main/query-parts loc])
           export-formats (get-in @settings [:data-out :accepted-formats])
           valid-export-formats
-            (reduce (fn [good-formats [format suitable-for]]
-                                         (if (= suitable-for :all)
-                                           (conj good-formats format)
-                                           (check-if-good good-formats @model-parts suitable-for format)
-                                           )) [] export-formats)]
-    (reduce
+          (reduce (fn [good-formats [format suitable-for]]
+                    (if (= suitable-for :all)
+                      (conj good-formats format)
+                      (check-if-good good-formats @model-parts suitable-for format))) [] export-formats)]
+      (reduce
        (fn [select format]
          (conj select [:option (name format)]))
        [:select.form-control
@@ -45,24 +42,21 @@
 (defn export-menu
   "UI element. Presents the modal to allow user to select an export format."
   [loc]
-    {:header [:h4 "Export this table as..." [:a.close {:on-click #(dispatch [:modal/close loc])} "x"]]
-     :body [:div.modal-body
-            [:form [:label "Select a format" [modal-body loc]]]
-            [:a {:id "hiddendownloadlink" :download "download"}]]
-     :footer [:button.btn.btn-primary {:on-click (fn [] (dispatch [:exporttable/download loc]))} "Download now!"]
-     })
+  {:header [:h4 "Export this table as..." [:a.close {:on-click #(dispatch [:modal/close loc])} "x"]]
+   :body [:div.modal-body
+          [:form [:label "Select a format" [modal-body loc]]]
+          [:a {:id "hiddendownloadlink" :download "download"}]]
+   :footer [:button.btn.btn-primary {:on-click (fn [] (dispatch [:exporttable/download loc]))} "Download now!"]})
 
 (defn exporttable [loc]
   [:button.btn.btn-default
-   {
-    ;:data-toggle "modal"
+   {;:data-toggle "modal"
     ;:data-target "#testModal"
     :type "button"
     :on-click
     (fn [e]
-      (dispatch [:prep-modal loc (export-menu loc)])
+      (dispatch [:prep-modal loc (export-menu loc)]))}
       ;(dispatch [:prep-modal loc [:div [:h1 {:on-click (fn [] (println "TEST"))} "Test"] [:p "thanks"]]])
 
-      )}
    [:i.fa.fa-download] " Export"])
 

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -41,9 +41,9 @@
            (str "Showing "
                 (inc (:start pagination)) " to "
                 (min
-                  (+ (:start pagination) (:limit pagination))
-                  (:iTotalRecords response))
+                 (+ (:start pagination) (:limit pagination))
+                 (:iTotalRecords response))
                 " of "
-                (.toLocaleString (:iTotalRecords response)) " rows"))]
+                (.toLocaleString (:iTotalRecords response))
 
-        ]]]]))
+                " rows"))]]]]]))

--- a/src/im_tables/views/dashboard/manager/codegen/main.cljs
+++ b/src/im_tables/views/dashboard/manager/codegen/main.cljs
@@ -39,9 +39,7 @@
                          {:type "checkbox"
                           :value ""
                           :on-change (fn [e] (dispatch [:main/set-codegen-option loc :highlight? (not highlight?)]))
-                          :checked highlight?}] " Highlight syntax"]]]
-         ]))))
-
+                          :checked highlight?}] " Highlight syntax"]]]]))))
 
 (defn save-to-disk [filename text lang]
   (let [blob (js/Blob. [text] #js {:type "text/plain;charset=utf8"})
@@ -59,30 +57,30 @@
         codegen-settings (subscribe [:codegen/options loc])
         max-height (r/atom nil)]
     (r/create-class
-      {:component-did-mount (fn [this]
+     {:component-did-mount (fn [this]
                               ; Store the max height of the viewport later used to
                               ; set a maximum height on the [:code] block below
-                              (reset! max-height (-> js/window js/$ (ocall :height)))
+                             (reset! max-height (-> js/window js/$ (ocall :height)))
+                             (ocall (js/$ "pre code") :each
+                                    (fn [i block]
+                                      (ocall js/hljs :highlightBlock block))))
+      :component-did-update (fn [this]
                               (ocall (js/$ "pre code") :each
                                      (fn [i block]
                                        (ocall js/hljs :highlightBlock block))))
-       :component-did-update (fn [this]
-                               (ocall (js/$ "pre code") :each
-                                      (fn [i block]
-                                        (ocall js/hljs :highlightBlock block))))
-       :reagent-render (fn [loc]
-                         (let [highlight? (:highlight? @codegen-settings)]
-                           [:div.container-fluid
-                            [:div.row
-                             [:div.col-xs-3 [options loc]]
-                             [:div.col-xs-9
-                              (if (nil? @code)
-                                [:pre [:code.nohighlight "Generating code... " [:i.fa.fa-fw.fa-spinner.fa-spin]]]
+      :reagent-render (fn [loc]
+                        (let [highlight? (:highlight? @codegen-settings)]
+                          [:div.container-fluid
+                           [:div.row
+                            [:div.col-xs-3 [options loc]]
+                            [:div.col-xs-9
+                             (if (nil? @code)
+                               [:pre [:code.nohighlight "Generating code... " [:i.fa.fa-fw.fa-spinner.fa-spin]]]
                                 ; Show the code and fix the height of the code container
                                 ; to prevent expanding over the viewport
-                                (if highlight?
-                                  [:pre [:code {:style {:max-height (str (/ @max-height 2) "px")}} @code]]
-                                  [:pre {:style {:max-height (str (/ @max-height 2) "px")}} @code]))]]]))})))
+                               (if highlight?
+                                 [:pre [:code {:style {:max-height (str (/ @max-height 2) "px")}} @code]]
+                                 [:pre {:style {:max-height (str (/ @max-height 2) "px")}} @code]))]]]))})))
 
 (defn modal-footer [loc]
   (let [code (subscribe [:codegen/formatted-code loc])

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -29,8 +29,7 @@
                                     selected? "label label-success disabled")}
                           [:i.fa.fa-tag]
                           (when (and model current-path name)
-                            (last (impath/display-name model (join "." (conj current-path name)))))
-                          ]])) (vals attributes)))
+                            (last (impath/display-name model (join "." (conj current-path name)))))]])) (vals attributes)))
          (into [:ul.collections.list-unstyled]
                (map (fn [{:keys [name referencedType name] :as collection}]
                       (let [referenced-class (get-in model [:classes (keyword referencedType)])]
@@ -75,8 +74,7 @@
               {:data-dismiss "modal"
                :disabled (< (count @selected) 1)
                :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
-              (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]]
-      )))
+              (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]]]]])))
 
 (defn modal-body []
   (fn [loc]
@@ -84,8 +82,7 @@
           selected (subscribe [:tree-view/selection loc])
           query (subscribe [:main/query loc])]
 
-      [tree-view loc @model @query @selected]
-      )))
+      [tree-view loc @model @query @selected])))
 
 (defn modal-footer []
   (fn [loc]
@@ -104,16 +101,12 @@
                      (dispatch [:tree-view/merge-new-columns loc])
                      ; Close the modal by clearing the modal value in app-db
                      (dispatch [:prep-modal loc nil]))}
-        (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]]
-      )))
+        (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]])))
 
 (defn make-modal [loc]
   {:header [:h3 "Add Columns"]
    :body [modal-body loc]
    :footer [modal-footer loc]})
-
-
-
 
 (defn main []
   (fn [loc]

--- a/src/im_tables/views/dashboard/pagination.cljs
+++ b/src/im_tables/views/dashboard/pagination.cljs
@@ -16,7 +16,7 @@
               :on-change (fn [e]
                            (dispatch [:imt.settings/update-pagination-limit loc (js/parseInt (oget e :target :value))]))}]
             (cond-> (map (fn [a] [:option {:value a} a]) (take-while (partial > total) show-amounts))
-                    (and total (< total 250)) (concat (list [:option {:value total} (str "All (" total ")")]))))]
+              (and total (< total 250)) (concat (list [:option {:value total} (str "All (" total ")")]))))]
      [:div.btn-group
       [:button.btn.btn-default
        {:disabled (< start 1)

--- a/src/im_tables/views/dashboard/save.cljs
+++ b/src/im_tables/views/dashboard/save.cljs
@@ -6,7 +6,6 @@
             [imcljs.path :as path :refer [walk class]]
             [im-tables.components.bootstrap :refer [modal]]))
 
-
 (defn join-with-arrows [col]
   (clojure.string/join " > " col))
 
@@ -42,9 +41,8 @@
                     ; Save the list
                     (dispatch [:imt.io/save-list loc (:name @state) (:query details) @state])
                     ; Close the modal by clearing the modal markup in app-db
-                    (dispatch [:prep-modal loc nil])
+                    (dispatch [:prep-modal loc nil]))]
 
-                    )]
     {:header [:h4 (str "Save a list of " (:count details) " " (if (< count 2) (name type) (plural (name type))))]
      :body [save-dialog state details on-submit]
      :footer [save-footer loc state details on-submit]}))
@@ -64,8 +62,7 @@
         (into [:ul]
               (map (fn [[path query]]
                      [:li [:a
-                           {
-                            ;:data-toggle "modal"
+                           {;:data-toggle "modal"
                             ;:data-target "#testModal"
                             :on-click (fn [] (dispatch [:prep-modal loc
                                                         (generate-dialog loc
@@ -76,8 +73,7 @@
 (defn save-menu []
   (fn [loc model path {:keys [query count]}]
     [:li
-     {
-      ;:data-toggle "modal"
+     {;:data-toggle "modal"
       ;:data-target "#testModal"
       :on-click (fn [] (dispatch [:prep-modal loc
                                   (generate-dialog loc
@@ -85,7 +81,6 @@
                                                     :count count
                                                     :type (name (path/class model path))})]))}
      [:a (str (serialize-path model path) " (" count ")")]]))
-
 
 (defn main [loc]
   (let [model (subscribe [:assets/model loc])

--- a/src/im_tables/views/dashboard/undo.cljs
+++ b/src/im_tables/views/dashboard/undo.cljs
@@ -12,10 +12,9 @@
         [:button.btn.btn-default
          {:disabled (not @undos)
           :on-click (fn []
-                      (dispatch [:undo loc])
+                      (dispatch [:undo loc]))}
                       ;(dispatch [:purge-redos loc])
 
-                      )}
          [:i.fa.fa-undo] " Undo"]
         [:button.btn.btn-default.dropdown-toggle {:data-toggle "dropdown"
                                                   :disabled (not @undos)} [:span.caret]]
@@ -28,10 +27,9 @@
        (when @redos
          [:div.btn-group
           [:button.btn.btn-default
-           {
-            :disabled (not @redos)
+           {:disabled (not @redos)
             :on-click (fn []
-                        (dispatch [:redo loc])
+                        (dispatch [:redo loc]))}
                         ;(dispatch [:purge-redos loc])
-                        )}
+
            [:i.fa.fa-repeat] " Redo"]])])))

--- a/src/im_tables/views/graphs/histogram.cljs
+++ b/src/im_tables/views/graphs/histogram.cljs
@@ -1,6 +1,5 @@
 (ns im-tables.views.graphs.histogram)
 
-
 (defn linear-scale [[r1-lower r1-upper] [r2-lower r2-upper]]
   (fn [v]
     (+ (/ (* (- v r1-lower) (- r2-upper r2-lower))

--- a/src/im_tables/views/table/body/main.cljs
+++ b/src/im_tables/views/table/body/main.cljs
@@ -23,14 +23,13 @@
   [:table.table.table-striped.table-condensed.table-bordered.summary-table
    (into [:tbody]
          (map-indexed
-           (fn [idx column-header]
-             (if-let [v (get-in value (dot-split (get (:views summary) idx)))]
-               (let [v (if (and (string? v) (> (count v) 200)) (str (clojure.string/join (take 200 v)) "...") v)]
-                 [:tr
-                  [:td (clojure.string/join " > " (drop 1 (clojure.string/split column-header " > ")))]
-                  [:td.truncate-text v]])))
-           column-headers))])
-
+          (fn [idx column-header]
+            (if-let [v (get-in value (dot-split (get (:views summary) idx)))]
+              (let [v (if (and (string? v) (> (count v) 200)) (str (clojure.string/join (take 200 v)) "...") v)]
+                [:tr
+                 [:td (clojure.string/join " > " (drop 1 (clojure.string/split column-header " > ")))]
+                 [:td.truncate-text v]])))
+          column-headers))])
 
 (defn poppable
   "Wrap child(ren) in a Bootstrap popover, see render function for default values. Ex:
@@ -39,30 +38,29 @@
   []
   (let [dom (reagent/atom nil)]
     (reagent/create-class
-      {:name "Poppable"
-       :component-did-mount (fn []
+     {:name "Poppable"
+      :component-did-mount (fn []
                               ; Initiate popover functionality
-                              (some-> @dom (ocall :popover)))
-       :component-did-update (fn []
+                             (some-> @dom (ocall :popover)))
+      :component-did-update (fn []
                                ; When the popover is open...
-                               (when (some true? (-> @dom
-                                                     (ocall :data "bs.popover")
-                                                     (oget :inState)
-                                                     js->clj
-                                                     vals))
+                              (when (some true? (-> @dom
+                                                    (ocall :data "bs.popover")
+                                                    (oget :inState)
+                                                    js->clj
+                                                    vals))
                                  ; ...then re-open it with the new content
-                                 (-> @dom (ocall :popover "show"))))
-       :reagent-render (fn [props & [remaining]]
-                         [:span
-                          (merge {:data-trigger "hover"
-                                  :data-html true
-                                  :data-container "body"
-                                  :data-content nil
-                                  :data-placement "auto right"
-                                  :ref (fn [el] (some->> el js/$ (reset! dom)))}
-                                 props)
-                          remaining])})))
-
+                                (-> @dom (ocall :popover "show"))))
+      :reagent-render (fn [props & [remaining]]
+                        [:span
+                         (merge {:data-trigger "hover"
+                                 :data-html true
+                                 :data-container "body"
+                                 :data-content nil
+                                 :data-placement "auto right"
+                                 :ref (fn [el] (some->> el js/$ (reset! dom)))}
+                                props)
+                         remaining])})))
 
 (defn outer-join-table [loc]
   (let [model (subscribe [:assets/model loc])
@@ -81,17 +79,17 @@
             (-> [:table.table.table-bordered.sub-table]
                 (conj [:thead (into [:tr] (map (fn [th] [:th (last (impath/display-name @model th))]) (:view data)))])
                 (conj
-                  (into [:tbody]
-                        (map (fn [rows]
-                               (into [:tr]
-                                     (map (fn [{:keys [id value] :as c}]
-                                            [:td
-                                             [:a [poppable
-                                                  {:on-mouse-enter (fn [] (dispatch [:main/summarize-item loc c]))
-                                                   :data-content (->html (summary-table @(subscribe [:summary/item-details loc id])))}
-                                                  [:span (or value [no-value])]]]]))
-                                     rows))
-                             (:rows data)))))])]))))
+                 (into [:tbody]
+                       (map (fn [rows]
+                              (into [:tr]
+                                    (map (fn [{:keys [id value] :as c}]
+                                           [:td
+                                            [:a [poppable
+                                                 {:on-mouse-enter (fn [] (dispatch [:main/summarize-item loc c]))
+                                                  :data-content (->html (summary-table @(subscribe [:summary/item-details loc id])))}
+                                                 [:span (or value [no-value])]]]]))
+                                    rows))
+                            (:rows data)))))])]))))
 
 (defn cell [loc]
   (let [pop-el   (reagent/atom nil)
@@ -110,17 +108,17 @@
                        :data-content (->html (summary-table @(subscribe [:summary/item-details loc id])))}
 
              [:a {:href (url (merge
-                               data
-                               (:value @(subscribe [:summary/item-details loc id]))
-                               (get-in @settings [:links :vocab])))
+                              data
+                              (:value @(subscribe [:summary/item-details loc id]))
+                              (get-in @settings [:links :vocab])))
                   :on-click (fn []
                               (when (and on-click value)
                                 (do
                                   ; Call the provided on-click
                                   (on-click (url (merge
-                                                   data
-                                                   (:value @(subscribe [:summary/item-details loc id]))
-                                                   (get-in @settings [:links :vocab]))))
+                                                  data
+                                                  (:value @(subscribe [:summary/item-details loc id]))
+                                                  (get-in @settings [:links :vocab]))))
                                   ; Side effect!!
                                   ; Destroy the popover in case the table is embedded in an SPA
                                   ; otherwise it will stick after page routes
@@ -129,13 +127,12 @@
                                       (ocall :popover "destroy")))))}
               (or value [no-value])]]])]))))
 
-
 (defn table-row [loc row]
   (into [:tr]
         (map-indexed
-          (fn [idx c]
+         (fn [idx c]
             ;(reagent/flush)
-            ^{:key idx} [cell loc c]
+           ^{:key idx} [cell loc c])
             ;[:td (:value c)]
-            )
-          row)))
+
+         row)))

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -37,5 +37,5 @@
         [table-head loc views]
         (into [:tbody]
               (->>
-                (map second (into (sorted-map) (select-keys results (range start (+ start limit)))))
-                (map (fn [r] [table-body/table-row loc r]))))]])))
+               (map second (into (sorted-map) (select-keys results (range start (+ start limit)))))
+               (map (fn [r] [table-body/table-row loc r]))))]])))

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -8,8 +8,8 @@
             [clojure.string :as string]
             [oops.core :refer [oget ocall ocall! oapply oget+]])
   (:import
-    (goog.i18n NumberFormat)
-    (goog.i18n.NumberFormat Format)))
+   (goog.i18n NumberFormat)
+   (goog.i18n.NumberFormat Format)))
 
 (def nff
   (NumberFormat. Format/DECIMAL))
@@ -39,7 +39,6 @@
       (ocall! "parent")
       (ocall! "removeClass" "open")))
 
-
 (defn has-text?
   "Return true if a label contains a string"
   [needle haystack]
@@ -51,7 +50,6 @@
 
 (defn constraint-has-path? [view constraint]
   (= view (:path constraint)))
-
 
 (defn constraint-dropdown []
   (fn [{:keys [value on-change]}]
@@ -79,8 +77,8 @@
 (defn blank-constraint [loc path state]
   (fn [loc path]
     (let [submit-constraint (fn [] (dispatch
-                                     [:filters/add-constraint loc @state]
-                                     (reset! state {:path path :op "=" :value nil})))]
+                                    [:filters/add-constraint loc @state]
+                                    (reset! state {:path path :op "=" :value nil})))]
       [:div.imtable-constraint
        [:div.constraint-operator
         [constraint-dropdown
@@ -98,9 +96,7 @@
                                         input (.. e -target -value)]
                                     ;; submit when pressing enter & not blank.
                                     (when (and (= keycode 13) (not (clojure.string/blank? input)))
-                                      (submit-constraint)
-                                      )))}]]
-       ])))
+                                      (submit-constraint))))}]]])))
 
 (defn constraint []
   (fn [loc {:keys [path op value values code] :as const}]
@@ -115,7 +111,6 @@
        [:button.btn.btn-danger
         {:on-click (fn [] (dispatch [:filters/remove-constraint loc const]))
          :type "button"} [:i.fa.fa-times]]])))
-
 
 (defn filter-view [loc view blank-constraint-atom]
   (let [response (subscribe [:selection/response loc view])
@@ -141,8 +136,8 @@
           [:div.btn-group
            [:button.btn.btn-default
             {:on-click (fn [] (dispatch
-                                [:filters/add-constraint loc @blank-constraint-atom]
-                                (reset! blank-constraint-atom {:path view :op "=" :value nil})))
+                               [:filters/add-constraint loc @blank-constraint-atom]
+                               (reset! blank-constraint-atom {:path view :op "=" :value nil})))
              :type "button"} "Add More"]]
 
           [:div.btn-group
@@ -151,12 +146,11 @@
              :on-click (fn []
                          (when (not (clojure.string/blank? (:value @blank-constraint-atom)))
                            (dispatch
-                             [:filters/add-constraint loc @blank-constraint-atom]
-                             (reset! blank-constraint-atom {:path view :op "=" :value nil}))))
+                            [:filters/add-constraint loc @blank-constraint-atom]
+                            (reset! blank-constraint-atom {:path view :op "=" :value nil}))))
              ; don't put :data-toggle "dropdown" in here, it stops
              ; the form submitting.... silently. Nice.
-             :value "Apply"
-             }]]]]))))
+             :value "Apply"}]]]]))))
 
 (defn too-many-values []
   (fn []
@@ -225,51 +219,49 @@
         selections (subscribe [:selection/selections loc view])
         text-filter (subscribe [:selection/text-filter loc view])]
     (reagent/create-class
-      {:component-will-mount
-       (fn [])
-       :component-will-update
-       (fn [])
-       :reagent-render
-       (fn [loc view]
-         (let [close-fn (partial force-close (reagent/current-component))]
-           (if (false? @response)
-             [too-many-values]
-             (if (contains? (first (:results @response)) :min)
-               [numerical-column-summary loc view (:results @response) local-state]
-               [:form.form.column-summary
-                [:div.main-view
-                 [histogram/main (:results @response)]
-                 [filter-input loc view @text-filter]
-                 [:table.table.table-striped.table-condensed
-                  [:thead [:tr [:th
-                                (if (empty? @selections)
-                                  [:span {:title "Select all"
-                                          :on-click (fn [] (dispatch [:select/select-all loc view]))} [:i.fa.fa-check-square-o]]
-                                  [:span {:title "Deselect all"
-                                          :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])
-                                ] [:th "Item"] [:th "Count"]]]
-                  (into [:tbody]
-                        (->> (filter (partial has-text? @text-filter) (:results @response))
-                             (map (fn [{:keys [count item]}]
-                                    [:tr.hoverable
-                                     {:on-click (fn [e] (dispatch [:select/toggle-selection loc view item]))}
-                                     [:td
-                                      [:input
-                                       {:on-change (fn [])
-                                        :checked (contains? @selections item)
-                                        :type "checkbox"}]]
-                                     [:td (if item item [no-value])]
-                                     [:td
-                                      [:div count]]]))))]]
-                [:div.btn-toolbar.column-summary-toolbar
-                 [:button.btn.btn-primary
-                  {:type "button"
-                   :on-click (fn []
-                               (dispatch [:main/apply-summary-filter loc view])
-                               (close-fn))}
-                  [:i.fa.fa-filter]
-                  (str " Filter")]]]))))})))
-
+     {:component-will-mount
+      (fn [])
+      :component-will-update
+      (fn [])
+      :reagent-render
+      (fn [loc view]
+        (let [close-fn (partial force-close (reagent/current-component))]
+          (if (false? @response)
+            [too-many-values]
+            (if (contains? (first (:results @response)) :min)
+              [numerical-column-summary loc view (:results @response) local-state]
+              [:form.form.column-summary
+               [:div.main-view
+                [histogram/main (:results @response)]
+                [filter-input loc view @text-filter]
+                [:table.table.table-striped.table-condensed
+                 [:thead [:tr [:th
+                               (if (empty? @selections)
+                                 [:span {:title "Select all"
+                                         :on-click (fn [] (dispatch [:select/select-all loc view]))} [:i.fa.fa-check-square-o]]
+                                 [:span {:title "Deselect all"
+                                         :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])] [:th "Item"] [:th "Count"]]]
+                 (into [:tbody]
+                       (->> (filter (partial has-text? @text-filter) (:results @response))
+                            (map (fn [{:keys [count item]}]
+                                   [:tr.hoverable
+                                    {:on-click (fn [e] (dispatch [:select/toggle-selection loc view item]))}
+                                    [:td
+                                     [:input
+                                      {:on-change (fn [])
+                                       :checked (contains? @selections item)
+                                       :type "checkbox"}]]
+                                    [:td (if item item [no-value])]
+                                    [:td
+                                     [:div count]]]))))]]
+               [:div.btn-toolbar.column-summary-toolbar
+                [:button.btn.btn-primary
+                 {:type "button"
+                  :on-click (fn []
+                              (dispatch [:main/apply-summary-filter loc view])
+                              (close-fn))}
+                 [:i.fa.fa-filter]
+                 (str " Filter")]]]))))})))
 
 (defn filter-dropdown-menu [loc view idx col-count]
   (let [query (subscribe [:main/query loc view])
@@ -301,17 +293,14 @@
          [:div.dropdown-menu
           {:class (when right? "dropdown-right")} [filter-view loc view blank-constraint-atom]]]))))
 
-
 (defn obj->clj [obj]
   (reduce (fn [total next-key]
             (assoc total (keyword next-key) (oget+ obj next-key))) {} (js-keys obj)))
-
 
 (defn align-right? [dom-node]
   (let [{left :left} (obj->clj (ocall dom-node :getBoundingClientRect))
         screen-width (oget js/window :innerWidth)]
     (> left (/ screen-width 2))))
-
 
 (defn toolbar []
   (let [right? (reagent/atom false)]

--- a/test/cljs/im_tables/runner.cljs
+++ b/test/cljs/im_tables/runner.cljs
@@ -1,5 +1,5 @@
 (ns im-tables.runner
-    (:require [doo.runner :refer-macros [doo-tests]]
-              [im-tables.core-test]))
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [im-tables.core-test]))
 
 (doo-tests 'im-tables.core-test)


### PR DESCRIPTION
Only the first tablerows request is necessary to display the content of the im-table. The remaining requests only populate data that will *probably* be used later on during interaction. By saving them for later, we will reduce the amount of initial HTTP requests from 3+ to only 1.

On the [Bluegenes report page for eve](http://localhost:5000/default/report/Gene/1007318) this gives the following performance difference on a cold start (full refresh) in prod mode:

**Before change**
1065 HTTP requests
19.19 seconds

**After change**
88 HTTP requests
6.27 seconds

This PR should be tested by comparing the network panel output in your browser's dev tools, and by testing that none of the functionality of im-tables-3 has degraded.
