### PR TITLE
Fix #59 breaking column summaries whoopsie

### DIFF
--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -526,39 +526,34 @@
 
 ;;;;;;;;;;;;;;
 
+(defn index-map
+  [results offset]
+  (->> results
+       (map-indexed (fn [idx item] [(+ idx offset) item]))
+       (into {})))
 
 (reg-event-db
  :main/initial-query-response
  (sandbox)
- (fn [db [_ loc {:keys [start]} results]]
-   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-         updated-results (assoc results :results new-results-map)]
-     (assoc db :response updated-results))))
+ (fn [db [_ loc {:keys [start]} response]]
+   (assoc db :response (update response :results index-map start))))
 
 (reg-event-fx
  :main/replace-query-response
  (sandbox)
- (fn [{db :db} [_ loc {:keys [start size]} results]]
-    ;(println "no effect replace")
-   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-         updated-results (assoc results :results new-results-map)]
-     {:db (assoc db :response updated-results)
-       ;:db         (assoc db :query-response results)
-      :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-                        (map (fn [view] [:main/summarize-column loc view]) (get results :views)))})))
+ (fn [{db :db} [_ loc {:keys [start]} response]]
+   {:db (assoc db :response (update response :results index-map start))
+    :dispatch-n (into [^:flush-dom [:hide-overlay loc]]
+                      (map (fn [view] [:main/summarize-column loc view])
+                           (get response :views)))}))
 
-(reg-event-fx
+(reg-event-db
  :main/merge-query-response
  (sandbox)
- (fn [{db :db} [_ loc {:keys [start size]} results]]
-    ;(println "no effect merge")
-   (let [new-results-map (into {} (map-indexed (fn [idx item] [(+ idx start) item]) (:results results)))
-         updated-results (assoc results :results (merge (get-in db [:response :results]) new-results-map))]
-     {:db (assoc db :response updated-results)})))
-       ;:db         (assoc db :query-response results)
-       ;:dispatch-n (into [^:flush-dom [:hide-overlay loc]]
-       ;                  (map (fn [view] [:main/summarize-column loc view]) (get results :views)))
-
+ (fn [db [_ loc {:keys [start]} response]]
+   (let [old-results (get-in db [:response :results])
+         new-results (index-map (:results response) start)]
+     (assoc db :response (assoc response :results (merge old-results new-results))))))
 
 (reg-event-fx
  :im-tables.main/run-query

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -48,7 +48,7 @@
         model (subscribe [:assets/model location])
         query (subscribe [:main/query location])
         collapsed-views (subscribe [:query-response/views-collapsed-by-joins location])
-        views (subscribe [:query-response/views])]
+        views (subscribe [:query-response/views location])]
     (reagent/create-class
      {:reagent-render
       (fn [location]
@@ -60,7 +60,7 @@
           [:div.im-table.relative
             ; When the mouse touches the table, set the flag to render the actual React components
            {:on-mouse-over (fn []
-                             (when @static?
+                             (when (and @static? (some? @response))
                                (dispatch [:main/deconstruct location])
                                (doseq [event (map (fn [view] [:main/summarize-column location view]) @views)]
                                  (dispatch event))


### PR DESCRIPTION
#59 needed a bit more work to get right.
I also cleaned up the query-response events, to make them drier and their intent clearer.

You can test this PR by starting im-tables-3 with `lein dev` and clicking the column summary button for a column (*Data Sets Description* should have values). Without this PR, it should return an erroneous empty list.