### PR TITLE
Clean up overlay and modal events

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
   :test-paths ["test/cljs"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
-                                    "test/js"]
+                                    "out" "test/js"]
 
   :figwheel {:css-dirs ["resources/public/css"]
              :server-port 3448}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -85,6 +85,5 @@
    :cache {:summaries {}
            :summary {}
            :selection {}
-           :overlay? false
            :filters {}
            :tree-view {:selection #{}}}})

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -83,20 +83,17 @@
     :im-tables/im-operation {:on-success [:imt.io/save-list-success]
                              :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins) options)}}))
 
-(reg-event-fx
- :prep-modal
- [(sandbox)]
- (fn [{db :db} [_ loc contents]]
-   {:db (assoc-in db [:cache :modal] contents)}))
+(reg-event-db
+ :modal/open
+ (sandbox)
+ (fn [db [_ loc contents]]
+   (assoc-in db [:cache :modal] contents)))
 
-(reg-event-fx
+(reg-event-db
  :modal/close
  (sandbox)
- (fn [{db :db} [_ loc]]
-   (let [modal (ocall js/document :getElementById "testModal")]
-      ;;feigning a click is easier than dismissing it programatically for some reason
-     (ocall modal "click"))
-   {:db (assoc-in db [:cache :modal] nil)}))
+ (fn [db [_ loc]]
+   (assoc-in db [:cache :modal] nil)))
 
 (defn toggle-into-set [haystack needle]
   (if (some #{needle} haystack)

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -82,7 +82,7 @@
                               :response response
                               :query query)
                    :dispatch [:main/deconstruct loc]
-                   :im-tables/im-operation-chan {:on-success ^:flush-dom [:main/initial-query-response loc pagination]
+                   :im-tables/im-operation-chan {:on-success ^:flush-dom [:main/replace-query-response loc pagination]
                                                  :channel (fetch/table-rows service query {:start start
                                                                                            :size (* limit buffer)})}})))
 

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -33,11 +33,6 @@
    (get-in db (glue prefix [:query-parts-counts]))))
 
 (reg-sub
- :style/overlay?
- (fn [db [_ prefix]]
-   (get-in db (glue prefix [:cache :overlay?]))))
-
-(reg-sub
  :summary/item-details
  (fn [db [_ loc id]]
    (get-in db (glue loc [:cache :item-details id]))))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -11,16 +11,6 @@
 (def css-transition-group
   (reagent/adapt-react-class js/ReactTransitionGroup.CSSTransitionGroup))
 
-(defn table-thinking []
-  (fn [show?]
-    [css-transition-group
-     {:transition-name          "fade"
-      :transition-enter-timeout 50
-      :transition-leave-timeout 50}
-     (if show?
-       [:div.overlay
-        [:i.fa.fa-cog.fa-spin.fa-4x.fa-fw]])]))
-
 (defn custom-modal []
   (fn [loc {:keys [header body footer extra-class]}]
     [:div.im-modal
@@ -42,7 +32,6 @@
 (defn main [location]
   (let [response (subscribe [:main/query-response location])
         pagination (subscribe [:settings/pagination location])
-        overlay? (subscribe [:style/overlay? location])
         modal-markup (subscribe [:modal location])
         static? (reagent/atom true)
         model (subscribe [:assets/model location])
@@ -102,7 +91,3 @@
 
             ; Only show the modal when the modal subscription has a value
            (when @modal-markup [custom-modal location @modal-markup])]))})))
-
-            ; Cover the app whenever it's thinking
-            ;[table-thinking @overlay?]
-

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -14,8 +14,7 @@
 (defn custom-modal []
   (fn [loc {:keys [header body footer extra-class]}]
     [:div.im-modal
-     {:on-mouse-down (fn [e]
-                       (dispatch [:prep-modal loc nil]))}
+     {:on-mouse-down #(dispatch [:modal/close loc])}
      [:div.im-modal-content
       {:class extra-class
        :on-mouse-down (fn [e]

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -50,13 +50,7 @@
 
 (defn exporttable [loc]
   [:button.btn.btn-default
-   {;:data-toggle "modal"
-    ;:data-target "#testModal"
-    :type "button"
-    :on-click
-    (fn [e]
-      (dispatch [:prep-modal loc (export-menu loc)]))}
-      ;(dispatch [:prep-modal loc [:div [:h1 {:on-click (fn [] (println "TEST"))} "Test"] [:p "thanks"]]])
-
+   {:type "button"
+    :on-click #(dispatch [:modal/open loc (export-menu loc)])}
    [:i.fa.fa-download] " Export"])
 

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -23,7 +23,7 @@
           {:on-click (fn []
                        ; Clear the previous state of the column manager when (re)opening
                        (dispatch [:tree-view/clear-state loc])
-                       (dispatch [:prep-modal loc (saver/make-modal loc)]))}
+                       (dispatch [:modal/open loc (saver/make-modal loc)]))}
           [:i.fa.fa-columns] " Add Columns"]]
         [:div.btn-group [rel-manager/main loc]]
         [:div.btn-group [save/main loc]]

--- a/src/im_tables/views/dashboard/manager/codegen/main.cljs
+++ b/src/im_tables/views/dashboard/manager/codegen/main.cljs
@@ -87,7 +87,9 @@
         options (subscribe [:codegen/options loc])]
     (fn [loc]
       [:div.btn-toolbar.pull-right
-       [:button.btn.btn-default {:on-click (fn [] (dispatch [:prep-modal loc nil]))} "Close"]
+       [:button.btn.btn-default
+        {:on-click #(dispatch [:modal/close loc])}
+        "Close"]
        [:button.btn.btn-primary
         {:on-click (fn [] (save-to-disk "query" @code (:lang @options)))}
         [:i.fa.fa-save] " Download"]])))
@@ -107,7 +109,7 @@
        [:div.btn-group
         [:button.btn.btn-default
          {:on-click (fn []
-                      (dispatch [:prep-modal loc (build-modal loc)])
+                      (dispatch [:modal/open loc (build-modal loc)])
                       (dispatch [:main/generate-code loc @service (:model @service) @query (:lang @options)]))}
          [:i.fa.fa-code] (str " " (get-in languages [(:lang @options) :label]))]
         [:button.btn.btn-default.dropdown-toggle
@@ -116,5 +118,5 @@
               (map (fn [[value {:keys [label]}]]
                      [:li {:on-click (fn []
                                        (dispatch [:main/set-codegen-option loc :lang value true])
-                                       (dispatch [:prep-modal loc (build-modal loc)]))}
+                                       (dispatch [:modal/open loc (build-modal loc)]))}
                       [:a label]]) languages))]])))

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -93,7 +93,7 @@
           query (subscribe [:main/query loc])]
       [:div.btn-toolbar.pull-right
        [:button.btn.btn-default
-        {:on-click (fn [] (dispatch [:prep-modal loc nil]))}
+        {:on-click #(dispatch [:modal/close loc])}
         "Cancel"]
        [:button.btn.btn-success
         {:data-dismiss "modal"
@@ -102,7 +102,7 @@
                      ; Merge the new columns into the query
                      (dispatch [:tree-view/merge-new-columns loc])
                      ; Close the modal by clearing the modal value in app-db
-                     (dispatch [:prep-modal loc nil]))}
+                     (dispatch [:modal/close loc]))}
         (str "Add " (if (> (count @selected) 0) (str (count @selected) " ")) "columns")]])))
 
 (defn make-modal [loc]

--- a/src/im_tables/views/dashboard/manager/relationships/main.cljs
+++ b/src/im_tables/views/dashboard/manager/relationships/main.cljs
@@ -66,13 +66,15 @@
   (let [model (subscribe [:assets/model loc])]
     (fn [loc]
       [:div.btn-toolbar.pull-right
-       [:button.btn.btn-default {:on-click (fn [] (dispatch [:prep-modal loc nil]))} "Cancel"]
+       [:button.btn.btn-default
+        {:on-click #(dispatch [:modal/close loc])}
+        "Cancel"]
        [:button.btn.btn-success
         {:on-click (fn []
                      ; Apply the changes
                      (dispatch [:rel-manager/apply-changes loc])
                      ; Close the modal by clearing the markup from app-db
-                     (dispatch [:prep-modal loc nil]))}
+                     (dispatch [:modal/close loc]))}
         "Apply Changes"]])))
 
 (defn build-modal [loc]
@@ -90,5 +92,5 @@
                       ; Reset the state of the modal
                       (dispatch [:rel-manager/reset loc])
                       ; Build the modal markup and send it to app-db
-                      (dispatch [:prep-modal loc (build-modal loc)]))}
+                      (dispatch [:modal/open loc (build-modal loc)]))}
          [:i.fa.fa-share-alt] " Manage Relationships"]]])))

--- a/src/im_tables/views/dashboard/save.cljs
+++ b/src/im_tables/views/dashboard/save.cljs
@@ -30,7 +30,7 @@
   (fn [loc state details on-submit]
     [:div.btn-toolbar.pull-right
      [:button.btn.btn-default
-      {:on-click (fn [] (dispatch [:prep-modal loc nil]))}
+      {:on-click #(dispatch [:modal/close loc])}
       "Cancel"]
      [:button.btn.btn-success
       {:on-click on-submit}
@@ -42,7 +42,7 @@
                     ; Save the list
                     (dispatch [:imt.io/save-list loc (:name @state) (:query details) @state])
                     ; Close the modal by clearing the modal markup in app-db
-                    (dispatch [:prep-modal loc nil]))]
+                    (dispatch [:modal/close loc]))]
 
     {:header [:h4 (str "Save a list of " (:count details) " "
                        ;; It's possible that `count` is the string "..." if
@@ -67,27 +67,23 @@
         [:h4 class]
         (into [:ul]
               (map (fn [[path query]]
-                     [:li [:a
-                           {;:data-toggle "modal"
-                            ;:data-target "#testModal"
-                            :on-click (fn [] (dispatch [:prep-modal loc
-                                                        (generate-dialog loc
-                                                                         {:query query
-                                                                          :type class})]))}
+                     [:li [:a {:on-click
+                               #(dispatch [:modal/open loc
+                                           (generate-dialog loc
+                                                            {:query query
+                                                             :type class})])}
                            (serialize-path @model path)]]) details))]])))
 
 (defn save-menu [loc _model _path _details]
   (let [counts (subscribe [:main/query-parts-counts loc])]
     (fn [loc model path {:keys [query]}]
       (let [count (get @counts path "...")]
-        [:li
-         {;:data-toggle "modal"
-          ;:data-target "#testModal"
-          :on-click (fn [] (dispatch [:prep-modal loc
-                                      (generate-dialog loc
-                                                       {:query query
-                                                        :count count
-                                                        :type (name (path/class model path))})]))}
+        [:li {:on-click
+              #(dispatch [:modal/open loc
+                          (generate-dialog loc
+                                           {:query query
+                                            :count count
+                                            :type (name (path/class model path))})])}
          [:a (str (serialize-path model path) " (" count ")")]]))))
 
 (defn main [loc]

--- a/test/cljs/im_tables/test_utils.cljc
+++ b/test/cljs/im_tables/test_utils.cljc
@@ -92,5 +92,5 @@
   [location im-config & body]
   `(run-test-async
      (rf/dispatch-sync [:im-tables/load ~location ~im-config])
-     (wait-for [:main/initial-query-response]
+     (wait-for [:main/replace-query-response]
        ~@body)))


### PR DESCRIPTION
Remove `:show-overlay`, `:hide-overlay` and related code from sources. Also fixes #71 and cleans up in regards to `:prep-modal` being used to close modals.