### PR TITLE
Add a skeleton loader for column summary

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -233,6 +233,17 @@
         justify-content: center;
     }
 
+    .column-summary-loader {
+        width: 400px;
+        height: 600px;
+
+        opacity: 0.80;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     .column-summary .main-view,
     .filter-view {
         max-height: 60vh;
@@ -252,7 +263,7 @@
         }
     }
 
-    .column-summary .main-view .title {
+    .column-summary .title {
         margin: @spacer/2 @spacer/2;
     }
 

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -8,9 +8,6 @@
             [oops.core :refer [ocall]]
             [imcljs.path :as impath]))
 
-(def css-transition-group
-  (reagent/adapt-react-class js/ReactTransitionGroup.CSSTransitionGroup))
-
 (defn custom-modal []
   (fn [loc {:keys [header body footer extra-class]}]
     [:div.im-modal


### PR DESCRIPTION
Should probably be tested within Bluegenes to make sure it displays correctly.
I'll update the CSS in Bluegenes when I bump the im-tables-3 dependency version.