### PR TITLE
Make im-tables-3 more feature complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
 language: java
 jdk: openjdk8
+services:
+  - xvfb
+addons:
+  chrome: stable
+  apt:
+    packages:
+      - python3-pip
+      - python3-setuptools
+      - python3-wheel
 
 before_script:
+  # Use a newer version of Python
+  - pyenv versions
+  - pyenv global 3.6
+  # Setup biotestmine to test against
+  - pip3 install intermine-boot
+  - intermine_boot start local --build-im --im-branch bluegenes
   # Install lein - required to build the project
   - wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /tmp/lein
   - chmod +x /tmp/lein
@@ -10,6 +25,8 @@ before_script:
   - travis_retry lein deps
   # check code is well formatted
   - lein cljfmt check
+  # start a browser process for running kaocha tests
+  - google-chrome-stable --no-first-run &
   # setup node dependencies
   - npm install
 

--- a/README.md
+++ b/README.md
@@ -12,25 +12,49 @@ Development goals
 
 ## Usage from within ClojureScript
 
-To render an im-table, simply mount the component and pass in the relevant values:
+There are two ways to render an im-table. You can mount the component passing a location vector and dispatching the *load* event yourself.
 
 ```clojure
-[im-tables.views.core/main {:location [:some-location :within-app-db :to-store-values]
-                            :service {:root "beta.flymine.org/beta"
-                                      :model some-intermine-model         ; Optional
-                                      :summary-fields some-summary-fields ; Optional
-                                      }
-                            :settings {:pagination {:limit 10}}
-                            :response some-response-of-tablerows          ; Optional
-                            :query {:from "Gene"
-                                    :select ["symbol"
-                                             "secondaryIdentifier"
-                                             "primaryIdentifier"
-                                             "organism.name"
-                                             "dataSets.name"]
-                                    :where [{:path "Gene.symbol"
-                                             :op "LIKE"
-                                             :value "M*"}]}}]
+[im-tables.core/table [:some-location :within-app-db :to-store-values]]
+
+;; In the `:component-did-mount` lifecycle or other suitable place.
+(re-frame.core/dispatch [:im-tables/load [:some-location :within-app-db :to-store-values]
+                         {:service {:root "beta.flymine.org/beta"
+                                    :model some-intermine-model         ; Optional
+                                    :summary-fields some-summary-fields ; Optional
+                                    }
+                          :settings {:pagination {:limit 10}}
+                          :response some-response-of-tablerows          ; Optional
+                          :query {:from "Gene"
+                                  :select ["symbol"
+                                           "secondaryIdentifier"
+                                           "primaryIdentifier"
+                                           "organism.name"
+                                           "dataSets.name"]
+                                  :where [{:path "Gene.symbol"
+                                           :op "LIKE"
+                                           :value "M*"}]}}])
+```
+
+The other way is to pass in the entire map to have the im-table dispatch the *load* event automatically on mount.
+
+```clojure
+[im-tables.core/table {:location [:some-location :within-app-db :to-store-values]
+                       :service {:root "beta.flymine.org/beta"
+                                 :model some-intermine-model         ; Optional
+                                 :summary-fields some-summary-fields ; Optional
+                                 }
+                       :settings {:pagination {:limit 10}}
+                       :response some-response-of-tablerows          ; Optional
+                       :query {:from "Gene"
+                               :select ["symbol"
+                                        "secondaryIdentifier"
+                                        "primaryIdentifier"
+                                        "organism.name"
+                                        "dataSets.name"]
+                               :where [{:path "Gene.symbol"
+                                        :op "LIKE"
+                                        :value "M*"}]}}]
 ```
 
 Some of the values are optional, and if supplied they will not be fetched when the component is mounted. This allows you to fetch a resource once and share it across components, or to render a table of query results that have already been fetched.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Make sure to first run `npm install` to install the dependencies required to run
 lein kaocha
 ```
 
+*Note: Running tests requires you to have a [Biotestmine](https://github.com/intermine/biotestmine) running locally. The easiest way to achieve this is by using [intermine_boot](https://github.com/intermine/intermine_boot).*
+
 ## Production Build
 
 ### Deploying to Heroku

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # im-tables
 
+Travis: [![Build Status](https://travis-ci.org/intermine/im-tables-3.svg?branch=dev)](https://travis-ci.org/intermine/im-tables-3)
+
 [![Clojars Project](https://img.shields.io/clojars/v/org.intermine/im-tables.svg)](https://clojars.org/org.intermine/im-tables)
 
 A result viewer for Intermine data.

--- a/less/calendar.less
+++ b/less/calendar.less
@@ -1,0 +1,226 @@
+// Taken from https://github.com/gpbl/react-day-picker/blob/f645424337d324d7d42efd0c93e140a32c33240f/lib/style.css
+// Edit to your hearts content!
+/* DayPicker styles */
+
+.DayPicker {
+  display: inline-block;
+  font-size: 1rem;
+}
+
+.DayPicker-wrapper {
+  position: relative;
+
+  flex-direction: row;
+  padding-bottom: 1em;
+
+  -webkit-user-select: none;
+
+     -moz-user-select: none;
+
+      -ms-user-select: none;
+
+          user-select: none;
+}
+
+.DayPicker-Months {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.DayPicker-Month {
+  display: table;
+  margin: 0 1em;
+  margin-top: 1em;
+  border-spacing: 0;
+  border-collapse: collapse;
+
+  -webkit-user-select: none;
+
+     -moz-user-select: none;
+
+      -ms-user-select: none;
+
+          user-select: none;
+}
+
+.DayPicker-NavBar {
+}
+
+.DayPicker-NavButton {
+  position: absolute;
+  top: 1em;
+  right: 1.5em;
+  left: auto;
+
+  display: inline-block;
+  margin-top: 2px;
+  width: 1.25em;
+  height: 1.25em;
+  background-position: center;
+  background-size: 50%;
+  background-repeat: no-repeat;
+  color: #8B9898;
+  cursor: pointer;
+}
+
+.DayPicker-NavButton:hover {
+  opacity: 0.8;
+}
+
+.DayPicker-NavButton--prev {
+  margin-right: 1.5em;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAVVJREFUWAnN2G0KgjAYwPHpGfRkaZeqvgQaK+hY3SUHrk1YzNLay/OiEFp92I+/Mp2F2Mh2lLISWnflFjzH263RQjzMZ19wgs73ez0o1WmtW+dgA01VxrE3p6l2GLsnBy1VYQOtVSEH/atCCgqpQgKKqYIOiq2CBkqtggLKqQIKgqgCBjpJ2Y5CdJ+zrT9A7HHSTA1dxUdHgzCqJIEwq0SDsKsEg6iqBIEoq/wEcVRZBXFV+QJxV5mBtlDFB5VjYTaGZ2sf4R9PM7U9ZU+lLuaetPP/5Die3ToO1+u+MKtHs06qODB2zBnI/jBd4MPQm1VkY79Tb18gB+C62FdBFsZR6yeIo1YQiLJWMIiqVjQIu1YSCLNWFgijVjYIuhYYCKoWKAiiFgoopxYaKLUWOii2FgkophYp6F3r42W5A9s9OcgNvva8xQaysKXlFytoqdYmQH6tF3toSUo0INq9AAAAAElFTkSuQmCC');
+}
+
+.DayPicker-NavButton--next {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAXRJREFUWAnN119ugjAcwPHWzJ1gnmxzB/BBE0n24m4xfNkTaOL7wOtsl3AXMMb+Vjaa1BG00N8fSEibPpAP3xAKKs2yjzTPH9RAjhEo9WzPr/Vm8zgE0+gXATAxxuxtqeJ9t5tIwv5AtQAApsfT6TPdbp+kUBcgVwvO51KqVhMkXKsVJFXrOkigVhCIs1Y4iKlWZxB1rX4gwlpRIIpa8SDkWmggrFq4IIRaJKCYWnSgnrXIQV1r8YD+1Vrn+bReagysIFfLABRt31v8oBu1xEBttfRbltmfjgEcWh9snUS2kNdBK6WN1vrOWxObWsz+fjxevsxmB1GQDfINWiev83nhaoiB/CoOU438oPrhXS0WpQ9xc1ZQWxWHqUYe0I0qrKCQKjygDlXIQV2r0IF6ViEBxVTBBSFUQQNhVYkHIVeJAtkNsbQ7c1LtzP6FsObhb2rCKv7NBIGoq4SDmKoEgTirXAcJVGkFSVVpgoSrXICGUMUH/QBZNSUy5XWUhwAAAABJRU5ErkJggg==');
+}
+
+.DayPicker-NavButton--interactionDisabled {
+  display: none;
+}
+
+.DayPicker-Caption {
+  display: table-caption;
+  margin-bottom: 0.5em;
+  padding: 0 0.5em;
+  text-align: left;
+}
+
+.DayPicker-Caption > div {
+  font-weight: 500;
+  font-size: 1.15em;
+}
+
+.DayPicker-Weekdays {
+  display: table-header-group;
+  margin-top: 1em;
+}
+
+.DayPicker-WeekdaysRow {
+  display: table-row;
+}
+
+.DayPicker-Weekday {
+  display: table-cell;
+  padding: 0.5em;
+  color: #8B9898;
+  text-align: center;
+  font-size: 0.875em;
+}
+
+.DayPicker-Weekday abbr[title] {
+  border-bottom: none;
+  text-decoration: none;
+}
+
+.DayPicker-Body {
+  display: table-row-group;
+}
+
+.DayPicker-Week {
+  display: table-row;
+}
+
+.DayPicker-Day {
+  display: table-cell;
+  padding: 0.5em;
+  border-radius: 50%;
+  vertical-align: middle;
+  text-align: center;
+  cursor: pointer;
+}
+
+.DayPicker-WeekNumber {
+  display: table-cell;
+  padding: 0.5em;
+  min-width: 1em;
+  border-right: 1px solid #EAECEC;
+  color: #8B9898;
+  vertical-align: middle;
+  text-align: right;
+  font-size: 0.75em;
+  cursor: pointer;
+}
+
+.DayPicker--interactionDisabled .DayPicker-Day {
+  cursor: default;
+}
+
+.DayPicker-Footer {
+  padding-top: 0.5em;
+}
+
+.DayPicker-TodayButton {
+  border: none;
+  background-color: transparent;
+  background-image: none;
+  box-shadow: none;
+  color: #4A90E2;
+  font-size: 0.875em;
+  cursor: pointer;
+}
+
+/* Default modifiers */
+
+.DayPicker-Day--today {
+  color: #D0021B;
+  font-weight: 700;
+}
+
+.DayPicker-Day--outside {
+  color: #8B9898;
+  cursor: default;
+}
+
+.DayPicker-Day--disabled {
+  color: #DCE0E0;
+  cursor: default;
+  /* background-color: #eff1f1; */
+}
+
+/* Example modifiers */
+
+.DayPicker-Day--sunday {
+  background-color: #F7F8F8;
+}
+
+.DayPicker-Day--sunday:not(.DayPicker-Day--today) {
+  color: #DCE0E0;
+}
+
+.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+  position: relative;
+
+  background-color: #4A90E2;
+  color: #F0F8FF;
+}
+
+.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover {
+  background-color: #51A0FA;
+}
+
+.DayPicker:not(.DayPicker--interactionDisabled)
+  .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
+  background-color: #F0F8FF;
+}
+
+/* DayPickerInput */
+
+.DayPickerInput {
+  display: inline-block;
+}
+
+.DayPickerInput-OverlayWrapper {
+  position: relative;
+}
+
+.DayPickerInput-Overlay {
+  position: absolute;
+  left: 0;
+  z-index: 1;
+
+  background: white;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}

--- a/less/modal.less
+++ b/less/modal.less
@@ -65,3 +65,40 @@
     }
 }
 
+.filter-manager {
+    .filter-item {
+        display: flex;
+        flex-flow: column;
+
+        .filter-name {
+            margin-bottom: 0.5em;
+        }
+
+        .imtable-constraint {
+            display: flex;
+            margin-bottom: 0.25em;
+
+            .constraint-operator {
+                margin-right: 1em;
+                min-width: 110px;
+
+                .form-control {
+                    height: 38px;
+                }
+            }
+
+            .constraint-input {
+                width: 100%;
+                margin-right: 1em;
+
+                .DayPickerInput {
+                    width: 175px;
+                }
+
+                .form-control {
+                    height: 38px;
+                }
+            }
+        }
+    }
+}

--- a/less/modal.less
+++ b/less/modal.less
@@ -101,4 +101,21 @@
             }
         }
     }
+
+    .add-filter-item {
+        display: flex;
+        flex-flow: column;
+
+        .filter-name {
+            margin-bottom: 0.5em;
+        }
+
+        .add-filter-controls {
+            display: flex;
+
+            .constraint-add {
+                margin-left: 1em;
+            }
+        }
+    }
 }

--- a/less/site.less
+++ b/less/site.less
@@ -578,10 +578,6 @@
     .ontop {
         background-color: @highlightcolor;
     }
-    .modal-body {
-        max-height: 70vh;
-        overflow: auto;
-    }
     .modal-header h3 {margin:0;}
 
     .table-history-detail {
@@ -624,5 +620,40 @@
     .constraint-select {
         width: 100%;
         font-size: 14px;
+
+        // The following nested selectors are for setting the height.
+        // Yes, it's this hard.
+        // EDIT: I commented it out since it's working fine for single values,
+        // but it won't grow in height if you select 2+ multiple values.
+        // Leaving this arduous task for a future endeavour.
+        // .constraint-select__control {
+        //     height: 34px;
+
+        //     .constraint-select__value-container {
+        //         height: 34px;
+        //         align-items: baseline;
+        //         padding: 0.5px 8px;
+        //     }
+
+        //     .constraint-select__placeholder {
+        //         line-height: 30px;
+        //     }
+
+        //     .constraint-select__value {
+        //         line-height: 30px !important;
+
+        //         .constraint-select__value-label {
+        //             line-height: 30px;
+        //         }
+        //     }
+
+        //     .constraint-select__input {
+        //         height: 30px;
+        //     }
+
+        //     .constraint-select__indicators {
+        //         height: 34px;
+        //     }
+        // }
     }
 }

--- a/less/site.less
+++ b/less/site.less
@@ -256,6 +256,7 @@
         .constraint-input {
             flex-grow: 1;
             padding: 0 0.3em;
+            color: initial;
         }
 
         .toolbar {

--- a/less/site.less
+++ b/less/site.less
@@ -291,7 +291,7 @@
     }
 
     .column-summary .main-view {
-        overflow: auto;
+        overflow: hidden;
     }
 
     .column-summary .title {
@@ -418,6 +418,7 @@
 
         .dropdown-menu {
             min-width: 360px;
+            max-width: 600px;
             padding: 0;
 
             position: absolute;
@@ -486,6 +487,37 @@
         .table-condensed > thead > tr > td,
         .table-condensed > thead > tr > th {
             padding: 4px;
+        }
+
+        table.table-scrollable {
+            margin-bottom: 0;
+
+            tbody {
+                display: block;
+                overflow-y: auto;
+                overflow-x: hidden;
+                max-height: 50vh;
+                max-width: 586px;
+            }
+
+            thead tr,
+            tbody tr {
+                display: table;
+            }
+
+            thead tr th:last-child {
+                padding-right: 1.2*@spacer;
+            }
+
+            thead tr th:first-of-type,
+            tbody tr td:first-of-type {
+                width: 25px;
+            }
+
+            thead tr th.data-item,
+            tbody tr td.data-item {
+                width: 100%;
+            }
         }
     }
 

--- a/less/site.less
+++ b/less/site.less
@@ -186,6 +186,10 @@
         transition: opacity 50ms ease-in;
     }
 
+    .table-container {
+        overflow: auto;
+    }
+
     .relative {
         position: relative;
     }
@@ -399,9 +403,12 @@
         border-right: solid 1px @histogram-bg;
     }
 
-    .dropdown-right {
-        right: 100%;
-        left: auto;
+    .dropdown {
+        // This would normally be `relative` so the dropdown can be positioned
+        // directly below it. However, we want the dropdown to escape the
+        // overflow which means we can't use `relative` and have to position
+        // it manually with JS instead.
+        position: unset;
     }
 
     .summary-toolbar {
@@ -412,6 +419,8 @@
         .dropdown-menu {
             min-width: 360px;
             padding: 0;
+
+            position: absolute;
         }
 
         .filter-icon.active-filter {

--- a/less/site.less
+++ b/less/site.less
@@ -505,10 +505,6 @@
                 display: table;
             }
 
-            thead tr th:last-child {
-                padding-right: 1.2*@spacer;
-            }
-
             thead tr th:first-of-type,
             tbody tr td:first-of-type {
                 width: 25px;
@@ -517,6 +513,11 @@
             thead tr th.data-item,
             tbody tr td.data-item {
                 width: 100%;
+            }
+
+            thead tr th:last-of-type,
+            tbody tr td:last-of-type {
+                padding-right: 1.2*@spacer;
             }
         }
     }

--- a/less/site.less
+++ b/less/site.less
@@ -247,20 +247,42 @@
 
     .column-summary .main-view,
     .filter-view {
-        max-height: 60vh;
+        padding: @spacer/2;
 
         .imtable-constraint {
             display: flex;
+            margin-bottom: @spacer/2;
+        }
+
+        .constraint-operator {
+            margin-right: @spacer/2;
+
+            .form-control {
+                height: 38px;
+            }
         }
 
         .constraint-input {
             flex-grow: 1;
-            padding: 0 0.3em;
-            color: initial;
+            // Remove green color from active filter.
+            color: rgb(51, 51, 51);
+
+            .DayPickerInput {
+                width: 175px;
+            }
+
+            .form-control {
+                height: 38px;
+            }
         }
 
-        .toolbar {
-            margin: 0 0.3em 0.3em;
+        .constraint-delete {
+            margin-left: @spacer/2;
+        }
+
+        .btn-toolbar {
+            margin-right: @spacer/3;
+            margin-bottom: @spacer/3;
         }
     }
 

--- a/less/site.less
+++ b/less/site.less
@@ -17,6 +17,7 @@
 @import "tooltip";
 @import "modal";
 @import "highlight";
+@import "calendar";
 
 .force-wrap {
 
@@ -247,7 +248,6 @@
     .column-summary .main-view,
     .filter-view {
         max-height: 60vh;
-        overflow: auto;
 
         .imtable-constraint {
             display: flex;
@@ -261,6 +261,10 @@
         .toolbar {
             margin: 0 0.3em 0.3em;
         }
+    }
+
+    .column-summary .main-view {
+        overflow: auto;
     }
 
     .column-summary .title {
@@ -614,5 +618,11 @@
     }
     .numerical-content-wrapper {
         padding: 10px;
+    }
+
+    // Applies to react-select third-party component.
+    .constraint-select {
+        width: 100%;
+        font-size: 14px;
     }
 }

--- a/less/site.less
+++ b/less/site.less
@@ -721,4 +721,15 @@
         //     }
         // }
     }
+
+    .table-error {
+        .button-group {
+            margin-top: @spacer;
+            margin-bottom: @spacer;
+
+            button {
+                margin-right: @spacer/2;
+            }
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
-
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -249,11 +248,9 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "graceful-fs": {
-
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -400,11 +397,9 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "resolve": {
-
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,10 @@
                  [inflections "0.13.2"]
                  [criterium "0.4.5"]
                  [org.intermine/imcljs "1.1.0"]
-                 [day8.re-frame/test "0.1.5"]]
+                 [day8.re-frame/test "0.1.5"]
+                 [cljsjs/react-day-picker "7.3.0-1"]
+                 [cljsjs/react-select "2.4.4-0"]
+                 [com.andrewmcveigh/cljs-time "0.5.2"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-less "1.7.5"]

--- a/project.clj
+++ b/project.clj
@@ -1,22 +1,22 @@
 (defproject org.intermine/im-tables "0.9.0"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
-                 [org.clojure/core.async "0.4.500"]
-                 [re-frame "0.10.8"]
+                 [org.clojure/core.async "1.1.587"]
+                 [re-frame "0.12.0"]
                  [day8.re-frame/async-flow-fx "0.1.0"]
                  [day8.re-frame/forward-events-fx "0.0.6"]
-                 [reagent "0.8.1"]
+                 [reagent "0.10.0"]
                  [cljsjs/react-transition-group "1.2.0-0"
                   :exclusions [cljsjs/react cljsjs/react-dom]]
                  [cljsjs/highlight "9.12.0-2"]
                  [compojure "1.6.1"]
-                 [ring "1.7.1"]
+                 [ring "1.8.0"]
                  [cljs-http "0.1.46"]
                  [joshkh/ctrlz "0.3.0"]
                  [binaryage/oops "0.7.0"]
                  [inflections "0.13.2"]
                  [criterium "0.4.5"]
-                 [org.intermine/imcljs "1.0.2"]
+                 [org.intermine/imcljs "1.1.0"]
                  [day8.re-frame/test "0.1.5"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
@@ -62,16 +62,16 @@
 
   :main im-tables.core
 
-  :profiles {:dev {:dependencies [[binaryage/devtools "0.9.10"]
-                                  [day8.re-frame/re-frame-10x "0.4.4"]
+  :profiles {:dev {:dependencies [[binaryage/devtools "1.0.0"]
+                                  [day8.re-frame/re-frame-10x "0.6.2"]
                                   [day8.re-frame/tracing "0.5.3"]
                                   [figwheel-sidecar "0.5.19"]
-                                  [cider/piggieback "0.4.1"]]
+                                  [cider/piggieback "0.4.2"]]
                    :plugins [[lein-figwheel "0.5.19"]]}
              :repl {:source-paths ["dev"]}
              :uberjar {:prep-tasks ["build"]}
-             :kaocha {:dependencies [[lambdaisland/kaocha "0.0-554"]
-                                     [lambdaisland/kaocha-cljs "0.0-59"]]}}
+             :kaocha {:dependencies [[lambdaisland/kaocha "1.0-612"]
+                                     [lambdaisland/kaocha-cljs "0.0-71"]]}}
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src"]

--- a/src/im_tables/components/bootstrap.cljs
+++ b/src/im_tables/components/bootstrap.cljs
@@ -1,5 +1,6 @@
 (ns im-tables.components.bootstrap
   (:require [reagent.core :as reagent]
+            [reagent.dom :as dom]
             [reagent.dom.server :as server]
             [oops.core :refer [ocall oapply oget oset!]]))
 
@@ -14,24 +15,24 @@
   (reagent/create-class
    {;:component-did-mount
      ;(fn [this]
-     ;  (let [node (reagent/dom-node this)] (ocall (-> node js/$) "popover")))
+     ;  (let [node (dom/dom-node this)] (ocall (-> node js/$) "popover")))
      ;:component-will-unmount
      ;(fn [this]
-     ;  (let [node (reagent/dom-node this)] (ocall (-> "popover" js/$) "remove")))
+     ;  (let [node (dom/dom-node this)] (ocall (-> "popover" js/$) "remove")))
      ;:component-did-update
      ;(fn [this]
-     ;  (.log js/console "me" (reagent/dom-node this))
-     ;  (let [node (reagent/dom-node this)]
+     ;  (.log js/console "me" (dom/dom-node this))
+     ;  (let [node (dom/dom-node this)]
      ;    (ocall (-> "popover" js/$) "remove")
      ;    (ocall (-> node js/$) "popover")))
     :component-did-mount
     (fn [this])
-       ;(.log js/console "d" (ocall (js/$ (reagent/dom-node this)) "popover"))
+       ;(.log js/console "d" (ocall (js/$ (dom/dom-node this)) "popover"))
 
     :component-did-update
     (fn [this]
-      (.log js/console "me" (js/$ (reagent/dom-node this)))
-      (-> (js/$ (reagent/dom-node this))
+      (.log js/console "me" (js/$ (dom/dom-node this)))
+      (-> (js/$ (dom/dom-node this))
            ;(ocall "popover" "destroy")
           (ocall "popover" "toggle")))
     :reagent-render
@@ -66,7 +67,7 @@
      {:name "Tooltip"
       :component-did-mount
       (fn [this]
-        (let [bb (ocall (reagent/dom-node this) "getBoundingClientRect")]
+        (let [bb (ocall (dom/dom-node this) "getBoundingClientRect")]
           (swap! mystate assoc
                  :width (oget bb "width")
                  :height (oget bb "height")

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -6,6 +6,7 @@
             [im-tables.subs]
             [im-tables.db :as db]
             [im-tables.views :as views]
+            [im-tables.views.core :refer [main]]
             [im-tables.config :as config]
             [imcljs.query :as query]
             [cljsjs.react-transition-group]
@@ -28,6 +29,17 @@
   (re-frame/clear-subscription-cache!)
   (dom/render [views/main-panel]
               (.getElementById js/document "app")))
+
+(defn table
+  "This is the primary means of including an im-table in a re-frame project.
+  Argument can be either a map with at minimum `:location`, `:service` and
+  `:query` keys, or a location vector. In the latter case you will need to
+  dispatch `:im-tables/load` yourself, with the location and map as arguments."
+  [{:keys [location] :as args}]
+  (when (map? args))
+    (re-frame/dispatch [:im-tables/load location (dissoc args :location)])
+  (fn [{:keys [location] :as loc}]
+    [main (or location loc)]))
 
 (defn ^:export init []
   (views/reboot-tables-fn)

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -1,5 +1,6 @@
 (ns im-tables.core
   (:require [reagent.core :as reagent]
+            [reagent.dom :as dom]
             [re-frame.core :as re-frame]
             [im-tables.events]
             [im-tables.subs]
@@ -21,8 +22,8 @@
     (println "dev mode")))
 
 (defn mount-root []
-  (reagent/render [views/main-panel]
-                  (.getElementById js/document "app")))
+  (dom/render [views/main-panel
+                  (.getElementById js/document "app")]))
 
 (defn ^:export init []
   #_(re-frame/dispatch-sync [:initialize-db

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -24,15 +24,11 @@
     (println "dev mode")))
 
 (defn mount-root []
+  (re-frame/clear-subscription-cache!)
   (dom/render [views/main-panel]
               (.getElementById js/document "app")))
 
 (defn ^:export init []
-  #_(re-frame/dispatch-sync [:initialize-db
-                             [:test :location]
-                             {:service {:root "www.flymine.org/query"}
-                              ;:service {:root "yeastmine.yeastgenome.org/yeastmine"}
-                              :query (query/sterilize-query db/outer-join-query)}])
-
+  (views/reboot-tables-fn)
   (dev-setup)
   (mount-root))

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -36,8 +36,8 @@
   `:query` keys, or a location vector. In the latter case you will need to
   dispatch `:im-tables/load` yourself, with the location and map as arguments."
   [{:keys [location] :as args}]
-  (when (map? args))
-    (re-frame/dispatch [:im-tables/load location (dissoc args :location)])
+  (when (map? args)
+    (re-frame/dispatch [:im-tables/load location (dissoc args :location)]))
   (fn [{:keys [location] :as loc}]
     [main (or location loc)]))
 

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -16,7 +16,8 @@
             [cljsjs.highlight.langs.perl]
             [cljsjs.highlight.langs.python]
             [cljsjs.highlight.langs.ruby]
-            [cljsjs.highlight.langs.java]))
+            [cljsjs.highlight.langs.java]
+            [cljsjs.highlight.langs.xml]))
 
 (defn dev-setup []
   (when config/debug?

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -9,6 +9,8 @@
             [im-tables.config :as config]
             [imcljs.query :as query]
             [cljsjs.react-transition-group]
+            [cljsjs.react-day-picker]
+            [cljsjs.react-select]
             [cljsjs.highlight]
             [cljsjs.highlight.langs.javascript]
             [cljsjs.highlight.langs.perl]

--- a/src/im_tables/core.cljs
+++ b/src/im_tables/core.cljs
@@ -22,8 +22,8 @@
     (println "dev mode")))
 
 (defn mount-root []
-  (dom/render [views/main-panel
-                  (.getElementById js/document "app")]))
+  (dom/render [views/main-panel]
+              (.getElementById js/document "app")))
 
 (defn ^:export init []
   #_(re-frame/dispatch-sync [:initialize-db

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -23,14 +23,20 @@
              (< s 400)) (dispatch (conj on-success response))
         on-failure (dispatch (conj on-failure response))
         :else
-        (do (when-let [loc (second on-success)]
-              ;; We are being sneaky in taking advantage of `loc` always being
-              ;; passed as the first event handler argument. If we find this
-              ;; fallback error event useful, we should require that all uses
-              ;; of this effect pass a `loc` key.
-              (when (sequential? loc)
-                ;; Dispatch generic network error event if no `on-failure` defined.
-                (dispatch [:error/response loc response])))
+        (do ;; I commented this out since in some cases, like fetching a
+            ;; column summary, you don't want the table to be replaced with
+            ;; an error message should it fail. Instead we need a less
+            ;; intrusive way of indicating failure for these cases, while
+            ;; `:error/response` should be reserved for when a query or its
+            ;; dependents fail.
+            #_(when-let [loc (second on-success)]
+                ;; We are being sneaky in taking advantage of `loc` always being
+                ;; passed as the first event handler argument. If we find this
+                ;; fallback error event useful, we should require that all uses
+                ;; of this effect pass a `loc` key.
+                (when (sequential? loc)
+                  ;; Dispatch generic network error event if no `on-failure` defined.
+                  (dispatch [:error/response loc response])))
             (.error js/console "Failed imcljs request" response))))))
 
 (reg-fx

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -11,4 +11,8 @@
 (reg-fx
  :im-tables/im-operation-chan
  (fn [{:keys [on-success on-failure response-format channel params]}]
-   (go (dispatch (conj on-success (<! channel))))))
+   (go
+     (let [{:keys [status] :as response} (<! channel)]
+       (cond
+         (< status 400) (dispatch (conj on-success response))
+         :else (dispatch (conj (or on-failure on-success) response)))))))

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -30,7 +30,7 @@
               ;; of this effect pass a `loc` key.
               (when (sequential? loc)
                 ;; Dispatch generic network error event if no `on-failure` defined.
-                (dispatch [:error/network loc response])))
+                (dispatch [:error/response loc response])))
             (.error js/console "Failed imcljs request" response))))))
 
 (reg-fx

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -29,15 +29,15 @@
             ;; intrusive way of indicating failure for these cases, while
             ;; `:error/response` should be reserved for when a query or its
             ;; dependents fail.
-            #_(when-let [loc (second on-success)]
+          #_(when-let [loc (second on-success)]
                 ;; We are being sneaky in taking advantage of `loc` always being
                 ;; passed as the first event handler argument. If we find this
                 ;; fallback error event useful, we should require that all uses
                 ;; of this effect pass a `loc` key.
-                (when (sequential? loc)
+              (when (sequential? loc)
                   ;; Dispatch generic network error event if no `on-failure` defined.
-                  (dispatch [:error/response loc response])))
-            (.error js/console "Failed imcljs request" response))))))
+                (dispatch [:error/response loc response])))
+          (.error js/console "Failed imcljs request" response))))))
 
 (reg-fx
  :im-tables/im-operation

--- a/src/im_tables/effects.cljs
+++ b/src/im_tables/effects.cljs
@@ -3,16 +3,51 @@
   (:require [re-frame.core :refer [reg-fx dispatch]]
             [cljs.core.async :refer [<! timeout close!]]))
 
+(defn im-operation
+  [{:keys [on-success on-failure response-format op channel params]}]
+  (go
+    (let [{:keys [statusCode status] :as response} (<! (or channel (op)))
+          ;; `statusCode` is part of the response body from InterMine.
+          ;; `status` is part of the response map created by cljs-http.
+          s (or statusCode status)
+          ;; Response can be nil or "" when offline.
+          valid-response? (and (some? response)
+                               (not= response ""))]
+      ;; Note that `s` can be nil for successful responses, due to
+      ;; imcljs applying a transducer on success. The proper way to
+      ;; check for null responses (which don't have a status code)
+      ;; is to check if the response itself is nil.
+      (cond
+        ;; This first clause will intentionally match on s=nil.
+        (and valid-response?
+             (< s 400)) (dispatch (conj on-success response))
+        on-failure (dispatch (conj on-failure response))
+        :else
+        (do (when-let [loc (second on-success)]
+              ;; We are being sneaky in taking advantage of `loc` always being
+              ;; passed as the first event handler argument. If we find this
+              ;; fallback error event useful, we should require that all uses
+              ;; of this effect pass a `loc` key.
+              (when (sequential? loc)
+                ;; Dispatch generic network error event if no `on-failure` defined.
+                (dispatch [:error/network loc response])))
+            (.error js/console "Failed imcljs request" response))))))
+
 (reg-fx
  :im-tables/im-operation
- (fn [{:keys [on-success on-failure response-format op params]}]
-   (go (dispatch (conj on-success (<! (op)))))))
+ (fn [op-map]
+   (im-operation op-map)))
 
 (reg-fx
  :im-tables/im-operation-chan
- (fn [{:keys [on-success on-failure response-format channel params]}]
-   (go
-     (let [{:keys [status] :as response} (<! channel)]
-       (cond
-         (< status 400) (dispatch (conj on-success response))
-         :else (dispatch (conj (or on-failure on-success) response)))))))
+ (fn [op-map]
+   (im-operation op-map)))
+
+;; Currently this only logs to console, but in the future we can decide to
+;; include more information and perhaps log to a reporting service.
+(reg-fx
+ :im-tables/log-error
+ (fn [[error-string data-map]]
+   (.error js/console
+           (str "im-tables: " error-string)
+           (clj->js data-map))))

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -74,7 +74,15 @@
 (reg-event-db
  :imt.io/save-list-success
  (fn [db [_ response]]
-   (.debug js/console "List Saved" response)
+   ;; This event only exists so it can be intercepted by BlueGenes to display
+   ;; an alert. So do not delete it even if it looks like a noop!
+   db))
+
+(reg-event-db
+ :imt.io/save-list-failure
+ (fn [db [_ response]]
+   ;; This event only exists so it can be intercepted by BlueGenes to display
+   ;; an alert. So do not delete it even if it looks like a noop!
    db))
 
 (reg-event-fx
@@ -83,6 +91,7 @@
  (fn [{db :db} [_ loc name query options]]
    {:db db
     :im-tables/im-operation {:on-success [:imt.io/save-list-success]
+                             :on-failure [:imt.io/save-list-failure]
                              :op (partial save/im-list-from-query (get db :service) name (dissoc query :sortOrder :joins) options)}}))
 
 (reg-event-db

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -19,7 +19,8 @@
             [clojure.string :as string :refer [split join starts-with?]]
             [clojure.set :as set]
             [cljs.core.async :refer [close! <! chan]]
-            [reagent.core :as r]))
+            [reagent.core :as r]
+            [im-tables.utils :refer [response->error]]))
 
 (joshkh.undo/undo-config!
   ; This function is used to only store certain parts
@@ -718,16 +719,7 @@
  :error/response
  (sandbox)
  (fn [{db :db} [_ loc res]]
-   (let [error-type (if (get-in res [:body :error]) :query :network)]
-     (cond-> {:db (assoc db :error {:type error-type
-                                    :response res})}
+   (let [{error-type :type :as error-map} (response->error res)]
+     (cond-> {:db (assoc db :error error-map)}
        (= error-type :network)
        (assoc :im-tables/log-error ["Network error" {:response res}])))))
-
-(reg-event-db
- :error/boundary-catch
- (sandbox)
- (fn [db [_ loc error info]]
-   (assoc db :error {:type :boundary
-                     :error error
-                     :info info})))

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -495,10 +495,10 @@
                        (and from existing-from?)
                        (update :where
                                (partial mapv
-                                 (fn [{:keys [path op] :as c}]
-                                   (if (and (= path view) (= op ">="))
-                                     (assoc c :value from)
-                                     c))))
+                                        (fn [{:keys [path op] :as c}]
+                                          (if (and (= path view) (= op ">="))
+                                            (assoc c :value from)
+                                            c))))
 
                        (and from (not existing-from?))
                        (constraint-append {:path view
@@ -508,10 +508,10 @@
                        (and to existing-to?)
                        (update :where
                                (partial mapv
-                                 (fn [{:keys [path op] :as c}]
-                                   (if (and (= path view) (= op "<="))
-                                     (assoc c :value to)
-                                     c))))
+                                        (fn [{:keys [path op] :as c}]
+                                          (if (and (= path view) (= op "<="))
+                                            (assoc c :value to)
+                                            c))))
 
                        (and to (not existing-to?))
                        (constraint-append {:path view

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -141,7 +141,7 @@
   (let [letter (consts->letter (:where query))
         constraint+code (assoc constraint :code letter)]
     (-> query
-        (update :where conj constraint+code)
+        (update :where (fnil conj []) constraint+code)
         (update :constraintLogic logic-append letter))))
 
 (reg-event-db

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -629,7 +629,9 @@
                                            (get db :query)
                                            {:start start
                                             :size (* limit (get-in db [:settings :buffer]))}))
-       {:db (assoc-in db [:cache :column-summary] {})
+       {:db (-> db
+                (assoc-in [:cache :column-summary] {})
+                (dissoc :error))
         :dispatch [:main/deconstruct loc :force? true]
         :im-tables/im-operation-chan
         {; Hand the request atom off to the effect that takes from it

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -735,6 +735,9 @@
  (sandbox)
  (fn [{db :db} [_ loc res]]
    (let [{error-type :type :as error-map} (response->error res)]
-     (cond-> {:db (assoc db :error error-map)}
+     (cond-> {:db (-> db
+                      (assoc :error error-map)
+                      ;; We also want to remove any previous successful response.
+                      (dissoc :response))}
        (= error-type :network)
        (assoc :im-tables/log-error ["Network error" {:response res}])))))

--- a/src/im_tables/events.cljs
+++ b/src/im_tables/events.cljs
@@ -182,7 +182,6 @@
               (assoc-in [:temp-query :where] constraints')
               (assoc-in [:temp-query :constraintLogic] const-logic))})))
 
-
 (reg-event-fx
  :filters/save-changes
  [(sandbox) (undoable)]

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -2,6 +2,7 @@
   (:require-macros [cljs.core.async.macros :refer [go go-loop]])
   (:require [re-frame.core :refer [reg-event-fx reg-event-db reg-fx dispatch]]
             [cljs.core.async :refer [<! >! chan]]
+            [clojure.string :as str]
             [im-tables.db :as db]
             [im-tables.interceptors :refer [sandbox]]
             [imcljs.fetch :as fetch]
@@ -80,7 +81,11 @@
                   {:db (assoc db
                               :service service
                               :response response
-                              :query query)
+                              :query (cond-> query
+                                       (not (contains? query :constraintLogic))
+                                       (assoc :constraintLogic (->> (:where query)
+                                                                    (map :code)
+                                                                    (str/join " and ")))))
                    :dispatch [:main/deconstruct loc]
                    :im-tables/im-operation-chan {:on-success ^:flush-dom [:main/replace-query-response loc pagination]
                                                  :channel (fetch/table-rows service query {:start start

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -40,7 +40,8 @@
      {:db (assoc init-db :init init-db)
       :async-flow (boot-flow loc)})))
 
-;; Used to recover after an uncaught error (resets db to initial state).
+;; Used to reboot after an uncaught error (resets db to initial state).
+;; This will throw away any changes the user has made to the original query.
 (reg-event-fx
  :im-tables/restart
  (sandbox)
@@ -49,7 +50,8 @@
      {:db (assoc init-db :init init-db)
       :async-flow (boot-flow loc)})))
 
-;; Used to recover after a network error (doesn't touch db).
+;; Used to reboot after a network error (doesn't touch db).
+;; This will keep any changes the user has made to the original query.
 (reg-event-fx
  :im-tables/reload
  (sandbox)

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -1,11 +1,12 @@
 (ns im-tables.events.boot
-  (:require-macros [cljs.core.async.macros :refer [go go-loop]])
-  (:require [re-frame.core :refer [reg-event-fx reg-event-db reg-fx dispatch]]
-            [cljs.core.async :refer [<! >! chan]]
+  (:require-macros [cljs.core.async.macros :refer [go-loop]])
+  (:require [re-frame.core :refer [reg-event-fx reg-event-db]]
+            [cljs.core.async :refer [<!]]
             [clojure.string :as str]
             [im-tables.db :as db]
             [im-tables.interceptors :refer [sandbox]]
             [imcljs.fetch :as fetch]
+            [imcljs.auth :as auth]
             [imcljs.query :as im-query]))
 
 (defn deep-merge
@@ -16,93 +17,87 @@
     (last vals)))
 
 (defn boot-flow
-  [loc service]
-  {:first-dispatch [:imt.auth/fetch-anonymous-token loc service]
+  [loc]
+  {:first-dispatch [:imt.auth/init loc]
    :rules [{:when :seen?
             :events [:imt.auth/store-token]
-            :dispatch [:imt.main/fetch-assets loc]}
+            :dispatch-n [[:imt.main/fetch-model loc]
+                         [:imt.main/fetch-summary-fields loc]]}
            {:when :seen-all-of?
-            :events [:imt.main/save-summary-fields
-                     :imt.main/save-model]
-            :dispatch [:im-tables.main/run-query loc]}]})
+            :events [:imt.main/save-model
+                     :imt.main/save-summary-fields]
+            :dispatch [:im-tables/query loc]
+            :halt? true}]})
+;; TODO handle failures in the three fetch
 
-(defn <<!
-  "Given a collection of channels, returns a collection containing
-  the first result of each channel (similiar to JS Promise.all)"
-  [chans]
-  (go-loop [coll '()
-            chans (reverse chans)]
-    (if (seq chans)
-      (recur (conj coll (<! (first chans)))
-             (rest chans))
-      coll)))
+(reg-event-fx
+ :im-tables/load
+ (sandbox)
+ (fn [{db :db} [_ loc {:keys [query service location response settings] :as args}]]
+   {:db (assoc args :settings (deep-merge (:settings db/default-db) settings))
+    :async-flow (boot-flow loc)}))
 
+(reg-event-fx
+ :im-tables/reload
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   {:db db
+    :async-flow (boot-flow loc)}))
 
-
-; TODO - WIP - If assets are missing when a component is mounted then
-; fetch them and/or run necessary queries
-
-
-(reg-event-fx :im-tables/load
-              (sandbox)
-              (fn [{db :db} [_ loc {:keys [query service location response settings] :as args}]]
-                (let [new-db (assoc args :settings (deep-merge (:settings db/default-db) settings))]
-                  {:db new-db
-
-                   ; Then fetch InterMine assets from the server
-                   :im-tables/setup [loc new-db args]})))
-
-(reg-fx :im-tables/setup
-        (fn [[loc db {:keys [query service location response] :as args}]]
-
-          ; Fetch assets if they don't already exist in the database
-          ; Since <<! expects channels, we create channels for assets that already exist
-          ; and then immediately take from them
-
-          (go (let [[model summary-fields]
-                    (<!
-                     (<<!
-                      (-> []
-                            ; Get model from view arguments, or app-db, or remotely
-                          (conj (go (or (:model service) (-> db :service :model) (<! (fetch/model service)))))
-                            ; Get summary fields from view arguments, or app-db, or remotely
-                          (conj (go (or (:summary-fields service) (-> db :service :summary-fields) (<! (fetch/summary-fields service))))))))]
-                ; Now we have a service with all of the needed components
-                (let [complete-service (assoc service :model model :summary-fields summary-fields)]
-                  (dispatch [:im-tables/store-setup loc {:service complete-service
-                                                         :query (or (:query db) query)}]))))))
-
-(reg-event-fx :im-tables/store-setup
-              (sandbox)
-              (fn [{db :db} [_ loc {:keys [service response query]}]]
-                (let [{:keys [pagination buffer]} (:settings db)
-                      {:keys [start limit]}       pagination
-                      query (im-query/sterilize-query query)]
-                  {:db (assoc db
-                              :service service
-                              :response response
-                              :query (cond-> query
-                                       (not (contains? query :constraintLogic))
-                                       (assoc :constraintLogic (->> (:where query)
-                                                                    (map :code)
-                                                                    (str/join " and ")))))
-                   :dispatch [:main/deconstruct loc]
-                   :im-tables/im-operation-chan {:on-success ^:flush-dom [:main/replace-query-response loc pagination]
-                                                 :channel (fetch/table-rows service query {:start start
-                                                                                           :size (* limit buffer)})}})))
+;; Suggestion: Re-use `:im-tables.main/run-query` instead, if suitable.
+(reg-event-fx
+ :im-tables/query
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [service (:service db)
+         {:keys [pagination buffer]} (:settings db)
+         {:keys [start limit]}       pagination
+         query (im-query/sterilize-query (:query db))]
+     {:db (assoc db
+                 :query (cond-> query
+                          (not (contains? query :constraintLogic))
+                          (assoc :constraintLogic (->> (:where query)
+                                                       (map :code)
+                                                       (str/join " and ")))))
+      :dispatch [:main/deconstruct loc]
+      :im-tables/im-operation-chan
+      {:channel (fetch/table-rows service query {:start start
+                                                 :size (* limit buffer)})
+       :on-success ^:flush-dom [:main/replace-query-response loc pagination]
+       :on-failure ^:flush-dom [:error/network loc]}})))
 
 (reg-event-db
  :initialize-db
+ (sandbox)
  (fn [_] db/default-db))
+
+;; Suggestion: Instead of verifying that the token is valid, we could trust
+;; that it is, to save an extraneous HTTP request (we would instead have to
+;; handle getting a token at a later point, should it turn out to be invalid).
+(reg-event-fx
+ :imt.auth/init
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (let [token (get-in db [:service :token])]
+     (merge
+      {:db db}
+      (if (empty? token)
+        {:dispatch [:imt.auth/fetch-anonymous-token loc]}
+        {:im-tables/im-operation-chan
+         {:channel (auth/who-am-i? (:service db) token)
+          :on-success [:imt.auth/store-token loc token]
+          :on-failure [:imt.auth/fetch-anonymous-token loc]}})))))
 
 ; Fetch an anonymous token for a give
 (reg-event-fx
  :imt.auth/fetch-anonymous-token
  (sandbox)
- (fn [{db :db} [_ loc service]]
+ (fn [{db :db} [_ loc]]
    {:db db
-    :im-tables/im-operation {:on-success [:imt.auth/store-token loc]
-                             :op (partial fetch/session service)}}))
+    :im-tables/im-operation-chan
+    {:channel (fetch/session (:service db))
+     :on-success [:imt.auth/store-token loc]
+     :on-failure [:error/network loc]}}))
 
 ; Store an auth token for a given mine
 (reg-event-db
@@ -112,29 +107,43 @@
    (assoc-in db [:service :token] token)))
 
 (reg-event-fx
- :fetch-asset
- (fn [{db :db} [_ im-op]]
-   {:db db
-    :im-tables/im-operation im-op}))
-
-(reg-event-fx
- :imt.main/fetch-assets
+ :imt.main/fetch-model
  (sandbox)
  (fn [{db :db} [_ loc]]
-   {:db db
-    :dispatch-n [[:fetch-asset {:on-success [:imt.main/save-summary-fields loc]
-                                :op (partial fetch/summary-fields (get db :service))}]
-                 [:fetch-asset {:on-success [:imt.main/save-model loc]
-                                :op (partial fetch/model (get db :service))}]]}))
+   (merge
+    {:db db}
+    (if (get-in db [:service :model])
+      {:dispatch [:imt.main/save-model loc]}
+      {:im-tables/im-operation-chan
+       {:channel (fetch/model (:service db))
+        :on-success [:imt.main/save-model loc]
+        :on-failure [:error/network loc]}}))))
+
+(reg-event-fx
+ :imt.main/fetch-summary-fields
+ (sandbox)
+ (fn [{db :db} [_ loc]]
+   (merge
+    {:db db}
+    (if (get-in db [:service :summary-fields])
+      {:dispatch [:imt.main/save-summary-fields loc]}
+      {:im-tables/im-operation-chan
+       {:channel (fetch/summary-fields (:service db))
+        :on-success [:imt.main/save-summary-fields loc]
+        :on-failure [:error/network loc]}}))))
 
 (reg-event-db
  :imt.main/save-model
  (sandbox)
  (fn [db [_ loc model]]
-   (assoc-in db [:service :model] model)))
+   (cond-> db
+     (not-empty model)
+     (assoc-in [:service :model] model))))
 
 (reg-event-db
  :imt.main/save-summary-fields
  (sandbox)
  (fn [db [_ loc summary-fields]]
-   (assoc-in db [:assets :summary-fields] summary-fields)))
+   (cond-> db
+     (not-empty summary-fields)
+     (assoc-in [:service :summary-fields] summary-fields))))

--- a/src/im_tables/events/boot.cljs
+++ b/src/im_tables/events/boot.cljs
@@ -28,7 +28,6 @@
                      :imt.main/save-summary-fields]
             :dispatch [:im-tables/query loc]
             :halt? true}]})
-;; TODO handle failures in the three fetch
 
 (reg-event-fx
  :im-tables/load
@@ -64,7 +63,7 @@
       {:channel (fetch/table-rows service query {:start start
                                                  :size (* limit buffer)})
        :on-success ^:flush-dom [:main/replace-query-response loc pagination]
-       :on-failure ^:flush-dom [:error/network loc]}})))
+       :on-failure ^:flush-dom [:error/response loc]}})))
 
 (reg-event-db
  :initialize-db
@@ -97,7 +96,7 @@
     :im-tables/im-operation-chan
     {:channel (fetch/session (:service db))
      :on-success [:imt.auth/store-token loc]
-     :on-failure [:error/network loc]}}))
+     :on-failure [:error/response loc]}}))
 
 ; Store an auth token for a given mine
 (reg-event-db
@@ -117,7 +116,7 @@
       {:im-tables/im-operation-chan
        {:channel (fetch/model (:service db))
         :on-success [:imt.main/save-model loc]
-        :on-failure [:error/network loc]}}))))
+        :on-failure [:error/response loc]}}))))
 
 (reg-event-fx
  :imt.main/fetch-summary-fields
@@ -130,7 +129,7 @@
       {:im-tables/im-operation-chan
        {:channel (fetch/summary-fields (:service db))
         :on-success [:imt.main/save-summary-fields loc]
-        :on-failure [:error/network loc]}}))))
+        :on-failure [:error/response loc]}}))))
 
 (reg-event-db
  :imt.main/save-model

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -268,3 +268,17 @@
      (when (and sortm (= (string/join "." (drop 1 (string/split view ".")))
                          (:path sortm)))
        (:direction sortm)))))
+
+(reg-sub
+ :filter-manager/filters
+ (fn [[_ loc]]
+   (subscribe [:main/temp-query loc]))
+ (fn [query [_ loc]]
+   (:where query)))
+
+(reg-sub
+ :filter-manager/constraint-logic
+ (fn [[_ loc]]
+   (subscribe [:main/temp-query loc]))
+ (fn [query [_ loc]]
+   (:constraintLogic query)))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -83,6 +83,11 @@
    (get-in db (glue prefix [:cache :column-summary view :filters :text]))))
 
 (reg-sub
+ :selection/possible-values
+ (fn [db [_ prefix view]]
+   (get-in db (glue prefix [:cache :possible-values view]))))
+
+(reg-sub
  :assets/model
  (fn [db [_ prefix]]
    (get-in db (glue prefix [:service :model]))))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -33,6 +33,11 @@
    (get-in db (glue prefix [:query-parts-counts]))))
 
 (reg-sub
+ :main/error
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:error]))))
+
+(reg-sub
  :summary/item-details
  (fn [db [_ loc id]]
    (get-in db (glue loc [:cache :item-details id]))))

--- a/src/im_tables/utils.cljs
+++ b/src/im_tables/utils.cljs
@@ -73,3 +73,11 @@
     {:type error-type
      :message (when (= error-type :query) error-msg)
      :response response}))
+
+(defn constraints->logic
+  "Generates the default 'A and B and ...' constraint logic string from a
+  sequence of constraints. Note that `:code` needs to be present on all
+  constraint maps."
+  [constraints]
+  (->> (map :code constraints)
+       (string/join " and ")))

--- a/src/im_tables/utils.cljs
+++ b/src/im_tables/utils.cljs
@@ -3,6 +3,7 @@
             [inflections.core :refer [plural]]
             [imcljs.path :as path]
             [clojure.string :as string]
+            [goog.json :as json]
             [goog.i18n.NumberFormat.Format])
   (:import [goog.i18n NumberFormat]
            [goog.i18n.NumberFormat Format]))
@@ -81,3 +82,10 @@
   [constraints]
   (->> (map :code constraints)
        (string/join " and ")))
+
+(defn clj->json
+  "Converts a Clojure data structure to JSON."
+  [x]
+  (some-> x
+          (clj->js)
+          (json/serialize)))

--- a/src/im_tables/utils.cljs
+++ b/src/im_tables/utils.cljs
@@ -64,3 +64,12 @@
        (string/join " ")
        plural))
 
+(defn response->error
+  "Convert an HTTP response to an error map."
+  [response]
+  (let [error-msg (or (get-in response [:body :error])
+                      (:body response))
+        error-type (if (string? error-msg) :query :network)]
+    {:type error-type
+     :message (when (= error-type :query) error-msg)
+     :response response}))

--- a/src/im_tables/utils.cljs
+++ b/src/im_tables/utils.cljs
@@ -70,9 +70,12 @@
   [response]
   (let [error-msg (or (get-in response [:body :error])
                       (:body response))
-        error-type (if (string? error-msg) :query :network)]
+        error-type (cond
+                     (nil? response)            :network
+                     (< (:status response) 500) :query
+                     :else                      :network)]
     {:type error-type
-     :message (when (= error-type :query) error-msg)
+     :message (when (string? error-msg) error-msg)
      :response response}))
 
 (defn constraints->logic

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -55,6 +55,21 @@
                       :url (fn [{:keys [mine class objectId] :as _vocab}]
                              (string/join "/" [nil mine "report" class objectId]))}}})
 
+(def covidmine-config
+  {:service {:root "https://test.intermine.org/covidmine"}
+   :query {:from "Distribution"
+           :select ["date"
+                    "totalConfirmed"
+                    "totalActive"
+                    "totalDeaths"
+                    "totalRecovered"
+                    "geoLocation.state"
+                    "geoLocation.country"]}
+   :settings {:pagination {:limit 10}
+              :links {:vocab {:mine "covidmine"}
+                      :url (fn [{:keys [mine class objectId] :as _vocab}]
+                             (string/join "/" [nil mine "report" class objectId]))}}})
+
 ; This function is used for testing purposes.
 ; When using im-tables in real life, you could call the view like so:
 ; [im-tables.views.core/main {:location ... :service ... :query ...}]
@@ -65,7 +80,7 @@
   ; (useful for stress testing)
   (let [number-of-tables 2
         reboot-tables-fn (fn [] (dotimes [n number-of-tables]
-                                  (dispatch [:im-tables/load [:test :location n] humanmine-config])))]
+                                  (dispatch [:im-tables/load [:test :location n] covidmine-config])))]
     (r/create-class
      {:component-did-mount reboot-tables-fn
       :reagent-render (let [show? (r/atom true)]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -73,6 +73,25 @@
                       :url (fn [{:keys [mine class objectId] :as _vocab}]
                              (string/join "/" [nil mine "report" class objectId]))}}})
 
+;; This query has a very wide column, making it great for testing overflow.
+(def flymine-config
+  {:service {:root "https://www.flymine.org/flymine"}
+   :query {:from "Gene"
+           :select ["primaryIdentifier"
+                    "symbol"
+                    "regulatoryRegions.primaryIdentifier"
+                    "regulatoryRegions.chromosome.primaryIdentifier"
+                    "regulatoryRegions.sequenceOntologyTerm.name"
+                    "regulatoryRegions.chromosomeLocation.end"
+                    "regulatoryRegions.chromosomeLocation.start"
+                    "regulatoryRegions.dataSets.dataSource.name"
+                    "regulatoryRegions.sequence.residues"]}
+   :settings {:pagination {:limit 10}
+              :links {:vocab {:mine "flymine"}
+                      :url (fn [{:keys [mine class objectId] :as _vocab}]
+                             (string/join "/" [nil mine "report" class objectId]))}}})
+
+
 ; This function is used for testing purposes.
 ; When using im-tables in real life, you could call the view like so:
 ; [im-tables.views.core/main {:location ... :service ... :query ...}]
@@ -82,7 +101,7 @@
 (def number-of-tables 1)
 (defn reboot-tables-fn []
   (dotimes [n number-of-tables]
-    (re-frame/dispatch-sync [:im-tables/load [:test :location n] covidmine-config])))
+    (re-frame/dispatch-sync [:im-tables/load [:test :location n] flymine-config])))
 
 (defn main-panel []
   (let [show? (r/atom true)]
@@ -100,6 +119,6 @@
             [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
              (if @show? "Unmount Tables" "Mount Tables")]]]]]]
        (when @show?
-         (into [:div]
+         (into [:div {:style {:max-width "100vh"}}]
                (->> (range 0 number-of-tables)
                     (map (fn [n] [main-view/main [:test :location n]])))))])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -1,5 +1,5 @@
 (ns im-tables.views
-  (:require [re-frame.core :as re-frame :refer [dispatch]]
+  (:require [re-frame.core :as re-frame]
             [im-tables.views.core :as main-view]
             [reagent.core :as r]
             [clojure.string :as string]
@@ -74,30 +74,29 @@
 ; When using im-tables in real life, you could call the view like so:
 ; [im-tables.views.core/main {:location ... :service ... :query ...}]
 
+; Increase this range to produce N number of tables on the same page
+; (useful for stress testing)
+(def number-of-tables 1)
+(defn reboot-tables-fn []
+  (dotimes [n number-of-tables]
+    (re-frame/dispatch-sync [:im-tables/load [:test :location n] covidmine-config])))
 
 (defn main-panel []
-  ; Increase these range to produce N number of tables on the same page
-  ; (useful for stress testing)
-  (let [number-of-tables 2
-        reboot-tables-fn (fn [] (dotimes [n number-of-tables]
-                                  (dispatch [:im-tables/load [:test :location n] covidmine-config])))]
-    (r/create-class
-     {:component-did-mount reboot-tables-fn
-      :reagent-render (let [show? (r/atom true)]
-                        (fn []
-                          [:div.container-fluid
-                           [:div.container
-                            [:div.panel.panel-info
-                             [:div.panel-heading (str "Global Test Controls for " number-of-tables " tables")]
-                             [:div.panel-body
-                              [:div.btn-toolbar
-                               [:div.btn-group
-                                [:button.btn.btn-default {:on-click reboot-tables-fn}
-                                 "Reboot Tables"]]
-                               [:div.btn-group
-                                [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
-                                 (if @show? "Unmount Tables" "Mount Tables")]]]]]]
-                           (when @show?
-                             (into [:div]
-                                   (->> (range 0 number-of-tables)
-                                        (map (fn [n] [main-view/main [:test :location n]])))))]))})))
+  (let [show? (r/atom true)]
+    (fn []
+      [:div.container-fluid
+       [:div.container
+        [:div.panel.panel-info
+         [:div.panel-heading (str "Global Test Controls for " number-of-tables " tables")]
+         [:div.panel-body
+          [:div.btn-toolbar
+           [:div.btn-group
+            [:button.btn.btn-default {:on-click reboot-tables-fn}
+             "Reboot Tables"]]
+           [:div.btn-group
+            [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
+             (if @show? "Unmount Tables" "Mount Tables")]]]]]]
+       (when @show?
+         (into [:div]
+               (->> (range 0 number-of-tables)
+                    (map (fn [n] [main-view/main [:test :location n]])))))])))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -59,15 +59,12 @@
   {:service {:root "https://test.intermine.org/covidmine"}
    :query {:from "Distribution"
            :select ["date"
-                    "totalConfirmed"
-                    "totalActive"
+                    "totalCases"
                     "totalDeaths"
-                    "totalRecovered"
-                    "geoLocation.state"
-                    "geoLocation.country"]
-           :where [{:path "Distribution.geoLocation.country"
-                    :op "="
-                    :value "US"}]}
+                    "newCases"
+                    "newDeaths"
+                    "geoLocation.country"
+                    "geoLocation.state"]}
    :settings {:pagination {:limit 10}
               :links {:vocab {:mine "covidmine"}
                       :url (fn [{:keys [mine class objectId] :as _vocab}]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -67,9 +67,7 @@
                     "geoLocation.country"]
            :where [{:path "Distribution.geoLocation.country"
                     :op "="
-                    :value "US"
-                    :code "A"}]
-           :constraintLogic "A"}
+                    :value "US"}]}
    :settings {:pagination {:limit 10}
               :links {:vocab {:mine "covidmine"}
                       :url (fn [{:keys [mine class objectId] :as _vocab}]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -64,7 +64,12 @@
                     "totalDeaths"
                     "totalRecovered"
                     "geoLocation.state"
-                    "geoLocation.country"]}
+                    "geoLocation.country"]
+           :where [{:path "Distribution.geoLocation.country"
+                    :op "="
+                    :value "US"
+                    :code "A"}]
+           :constraintLogic "A"}
    :settings {:pagination {:limit 10}
               :links {:vocab {:mine "covidmine"}
                       :url (fn [{:keys [mine class objectId] :as _vocab}]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -98,6 +98,8 @@
 
 ; Increase this range to produce N number of tables on the same page
 ; (useful for stress testing)
+
+
 (def number-of-tables 1)
 (defn reboot-tables-fn []
   (dotimes [n number-of-tables]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -101,7 +101,7 @@
 (def number-of-tables 1)
 (defn reboot-tables-fn []
   (dotimes [n number-of-tables]
-    (re-frame/dispatch-sync [:im-tables/load [:test :location n] flymine-config])))
+    (re-frame/dispatch-sync [:im-tables/load [:test :location n] covidmine-config])))
 
 (defn main-panel []
   (let [show? (r/atom true)]

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -119,6 +119,6 @@
             [:button.btn.btn-default {:on-click (fn [] (swap! show? not))}
              (if @show? "Unmount Tables" "Mount Tables")]]]]]]
        (when @show?
-         (into [:div {:style {:max-width "100vh"}}]
+         (into [:div {:style {:max-width "100vw"}}]
                (->> (range 0 number-of-tables)
                     (map (fn [n] [main-view/main [:test :location n]])))))])))

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -52,34 +52,35 @@
              [:div
                ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
               [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
-              [:table.table.table-condensed.table-bordered.table-striped
-                ; Good old static (fast) html table:
-               [:thead
-                (into [:tr]
-                      (->> @collapsed-views
-                           (map-indexed (fn [idx h]
-                                          (let [display-name (when (and @model h) (impath/display-name @model h))
-                                                active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
-                                             ; This is a simple HTML representation of
-                                             ; im-tables.views.table.head.controls/toolbar
-                                             ; If you modify this form or the one in the toolbar, please remember to modify both
-                                             ; or they won't look the same when the table is activated
-                                            [:th
-                                             [:div.summary-toolbar
-                                              [:i.fa.fa-sort.sort-icon]
-                                              [:i.fa.fa-times.remove-icon]
-                                              [:i.fa.fa-filter.dropdown-toggle.filter-icon
-                                               {:class (when active-filters "active-filter")}]
-                                              [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
-                                             [:div
-                                              [:div (last (drop-last display-name))]
-                                              [:div (last display-name)]]])))))]
-               (into [:tbody] (map (fn [row]
-                                     (into [:tr] (map (fn [cell]
-                                                        [:td
-                                                         (if-let [value (:value cell)]
-                                                           [:a value]
-                                                           [:a.no-value "NO VALUE"])]) row))) preview-rows))]]
+              [:div.table-container
+               [:table.table.table-condensed.table-bordered.table-striped
+                 ; Good old static (fast) html table:
+                [:thead
+                 (into [:tr]
+                       (->> @collapsed-views
+                            (map-indexed (fn [idx h]
+                                           (let [display-name (when (and @model h) (impath/display-name @model h))
+                                                 active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
+                                              ; This is a simple HTML representation of
+                                              ; im-tables.views.table.head.controls/toolbar
+                                              ; If you modify this form or the one in the toolbar, please remember to modify both
+                                              ; or they won't look the same when the table is activated
+                                             [:th
+                                              [:div.summary-toolbar
+                                               [:i.fa.fa-sort.sort-icon]
+                                               [:i.fa.fa-times.remove-icon]
+                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon
+                                                {:class (when active-filters "active-filter")}]
+                                               [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
+                                              [:div
+                                               [:div (last (drop-last display-name))]
+                                               [:div (last display-name)]]])))))]
+                (into [:tbody] (map (fn [row]
+                                      (into [:tr] (map (fn [cell]
+                                                         [:td
+                                                          (if-let [value (:value cell)]
+                                                            [:a value]
+                                                            [:a.no-value "NO VALUE"])]) row))) preview-rows))]]]
               ; Otherwise show the interactive React components
              [:div
               [dashboard/main location @response @pagination]

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -52,35 +52,36 @@
              [:div
                ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
               [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
-              [:div.table-container
-               [:table.table.table-condensed.table-bordered.table-striped
+              [table/handle-states location @response
+               [:div.table-container
+                [:table.table.table-condensed.table-bordered.table-striped
                  ; Good old static (fast) html table:
-                [:thead
-                 (into [:tr]
-                       (->> @collapsed-views
-                            (map-indexed (fn [idx h]
-                                           (let [display-name (when (and @model h) (impath/display-name @model h))
-                                                 active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
+                 [:thead
+                  (into [:tr]
+                        (->> @collapsed-views
+                             (map-indexed (fn [idx h]
+                                            (let [display-name (when (and @model h) (impath/display-name @model h))
+                                                  active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
                                               ; This is a simple HTML representation of
                                               ; im-tables.views.table.head.controls/toolbar
                                               ; If you modify this form or the one in the toolbar, please remember to modify both
                                               ; or they won't look the same when the table is activated
-                                             [:th
-                                              [:div.summary-toolbar
-                                               [:i.fa.fa-sort.sort-icon]
-                                               [:i.fa.fa-times.remove-icon]
-                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon
-                                                {:class (when active-filters "active-filter")}]
-                                               [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
-                                              [:div
-                                               [:div (last (drop-last display-name))]
-                                               [:div (last display-name)]]])))))]
-                (into [:tbody] (map (fn [row]
-                                      (into [:tr] (map (fn [cell]
-                                                         [:td
-                                                          (if-let [value (:value cell)]
-                                                            [:a value]
-                                                            [:a.no-value "NO VALUE"])]) row))) preview-rows))]]]
+                                              [:th
+                                               [:div.summary-toolbar
+                                                [:i.fa.fa-sort.sort-icon]
+                                                [:i.fa.fa-times.remove-icon]
+                                                [:i.fa.fa-filter.dropdown-toggle.filter-icon
+                                                 {:class (when active-filters "active-filter")}]
+                                                [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
+                                               [:div
+                                                [:div (last (drop-last display-name))]
+                                                [:div (last display-name)]]])))))]
+                 (into [:tbody] (map (fn [row]
+                                       (into [:tr] (map (fn [cell]
+                                                          [:td
+                                                           (if-let [value (:value cell)]
+                                                             [:a value]
+                                                             [:a.no-value "NO VALUE"])]) row))) preview-rows))]]]]
               ; Otherwise show the interactive React components
              [:div
               [dashboard/main location @response @pagination]

--- a/src/im_tables/views/core.cljs
+++ b/src/im_tables/views/core.cljs
@@ -1,12 +1,13 @@
 (ns im-tables.views.core
-  (:require [re-frame.core :refer [subscribe dispatch]]
+  (:require [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.core :as reagent]
             [im-tables.views.dashboard.main :as dashboard]
             [im-tables.views.table.core :as table]
             [im-tables.components.bootstrap :refer [modal]]
             [reagent.dom.server :as server]
-            [oops.core :refer [ocall]]
-            [imcljs.path :as impath]))
+            [oops.core :refer [ocall oget]]
+            [imcljs.path :as impath]
+            [im-tables.views.table.error :as error]))
 
 (defn custom-modal []
   (fn [loc {:keys [header body footer extra-class]}]
@@ -25,6 +26,32 @@
 (defn constraint-has-path? [view constraint]
   (= view (:path constraint)))
 
+(defn error-boundary
+  [props & children]
+  (let [caught? (reagent/atom false)
+        !error (reagent/atom nil)]
+    (reagent/create-class
+     {:display-name "ImTablesRootErrorBoundary"
+      :get-derived-state-from-error (fn [_]
+                                      (reset! caught? true)
+                                      #js {})
+      :component-did-catch (fn [_ error info]
+                             (reset! !error {:type :boundary
+                                             :error error
+                                             :info info}))
+      :render (fn [this]
+                (let [{:keys [location]} (reagent/props this)
+                      clear-error! (fn []
+                                     (dispatch-sync [:im-tables/restart location])
+                                     (reset! !error nil)
+                                     (reset! caught? false))]
+                  (if @caught?
+                    (when-let [error @!error]
+                      [:div.im-table.relative
+                       [error/failure location error
+                        :clear-error! clear-error!]])
+                    (into [:<>] (reagent/children this)))))})))
+
 (defn main [location]
   (let [response (subscribe [:main/query-response location])
         pagination (subscribe [:settings/pagination location])
@@ -33,59 +60,58 @@
         model (subscribe [:assets/model location])
         query (subscribe [:main/query location])
         collapsed-views (subscribe [:query-response/views-collapsed-by-joins location])]
-    (reagent/create-class
-     {:reagent-render
-      (fn [location]
-         ; The query results are stored in a map with the result index as the key.
-         ; In other words, we're not using a vector! To generate a speedy preview,
-         ; get the first n results to be shown as a simple table:
-         ; (get results 0), (get results 1), (get results 2) ... (get results limit)
-        (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
-          [:div.im-table.relative
-            ; When the mouse touches the table, set the flag to render the actual React components
-           {:on-mouse-over (fn []
-                             (when @static?
-                               (reset! static? false)))}
+    (fn [location]
+       ; The query results are stored in a map with the result index as the key.
+       ; In other words, we're not using a vector! To generate a speedy preview,
+       ; get the first n results to be shown as a simple table:
+       ; (get results 0), (get results 1), (get results 2) ... (get results limit)
+      (let [preview-rows (map (partial get (:results @response)) (range (:limit @pagination)))]
+        [error-boundary {:location location}
+         [:div.im-table.relative
+           ; When the mouse touches the table, set the flag to render the actual React components
+          {:on-mouse-over (fn []
+                            (when @static?
+                              (reset! static? false)))}
 
-           (if @static?
-              ; If static (optimised) then only show an HTML representations of the React components
-             [:div
-               ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
-              [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
-              [table/handle-states location @response
-               [:div.table-container
-                [:table.table.table-condensed.table-bordered.table-striped
-                 ; Good old static (fast) html table:
-                 [:thead
-                  (into [:tr]
-                        (->> @collapsed-views
-                             (map-indexed (fn [idx h]
-                                            (let [display-name (when (and @model h) (impath/display-name @model h))
-                                                  active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
-                                              ; This is a simple HTML representation of
-                                              ; im-tables.views.table.head.controls/toolbar
-                                              ; If you modify this form or the one in the toolbar, please remember to modify both
-                                              ; or they won't look the same when the table is activated
-                                              [:th
-                                               [:div.summary-toolbar
-                                                [:i.fa.fa-sort.sort-icon]
-                                                [:i.fa.fa-times.remove-icon]
-                                                [:i.fa.fa-filter.dropdown-toggle.filter-icon
-                                                 {:class (when active-filters "active-filter")}]
-                                                [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
-                                               [:div
-                                                [:div (last (drop-last display-name))]
-                                                [:div (last display-name)]]])))))]
-                 (into [:tbody] (map (fn [row]
-                                       (into [:tr] (map (fn [cell]
-                                                          [:td
-                                                           (if-let [value (:value cell)]
-                                                             [:a value]
-                                                             [:a.no-value "NO VALUE"])]) row))) preview-rows))]]]]
-              ; Otherwise show the interactive React components
-             [:div
-              [dashboard/main location @response @pagination]
-              [table/main location @response @pagination]])
+          (if @static?
+             ; If static (optimised) then only show an HTML representations of the React components
+            [:div
+              ; Force the dashboard buttons to be just HTML (their lights are on but no one is home)
+             [:div {:dangerouslySetInnerHTML {"__html" (server/render-to-static-markup [dashboard/main location @response @pagination])}}]
+             [table/handle-states location @response
+              [:div.table-container
+               [:table.table.table-condensed.table-bordered.table-striped
+                ; Good old static (fast) html table:
+                [:thead
+                 (into [:tr]
+                       (->> @collapsed-views
+                            (map-indexed (fn [idx h]
+                                           (let [display-name (when (and @model h) (impath/display-name @model h))
+                                                 active-filters (not-empty (filter (partial constraint-has-path? h) (:where @query)))]
+                                             ; This is a simple HTML representation of
+                                             ; im-tables.views.table.head.controls/toolbar
+                                             ; If you modify this form or the one in the toolbar, please remember to modify both
+                                             ; or they won't look the same when the table is activated
+                                             [:th
+                                              [:div.summary-toolbar
+                                               [:i.fa.fa-sort.sort-icon]
+                                               [:i.fa.fa-times.remove-icon]
+                                               [:i.fa.fa-filter.dropdown-toggle.filter-icon
+                                                {:class (when active-filters "active-filter")}]
+                                               [:i.fa.fa-bar-chart.dropdown-toggle {:data-toggle "dropdown"}]]
+                                              [:div
+                                               [:div (last (drop-last display-name))]
+                                               [:div (last display-name)]]])))))]
+                (into [:tbody] (map (fn [row]
+                                      (into [:tr] (map (fn [cell]
+                                                         [:td
+                                                          (if-let [value (:value cell)]
+                                                            [:a value]
+                                                            [:a.no-value "NO VALUE"])]) row))) preview-rows))]]]]
+             ; Otherwise show the interactive React components
+            [:div
+             [dashboard/main location @response @pagination]
+             [table/main location @response @pagination]])
 
-            ; Only show the modal when the modal subscription has a value
-           (when @modal-markup [custom-modal location @modal-markup])]))})))
+           ; Only show the modal when the modal subscription has a value
+          (when @modal-markup [custom-modal location @modal-markup])]]))))

--- a/src/im_tables/views/dashboard/main.cljs
+++ b/src/im_tables/views/dashboard/main.cljs
@@ -2,6 +2,7 @@
   (:require [im-tables.views.dashboard.pagination :as pager]
             [im-tables.views.dashboard.manager.columns.main :as column-manager]
             [im-tables.views.dashboard.manager.relationships.main :as rel-manager]
+            [im-tables.views.dashboard.manager.filters.main :as filter-manager]
             [im-tables.views.dashboard.undo :as undo]
             [im-tables.views.dashboard.save :as save]
             [im-tables.views.dashboard.manager.columns.main :as saver]
@@ -25,6 +26,7 @@
                        (dispatch [:tree-view/clear-state loc])
                        (dispatch [:modal/open loc (saver/make-modal loc)]))}
           [:i.fa.fa-columns] " Add Columns"]]
+        [:div.btn-group [filter-manager/main loc]]
         [:div.btn-group [rel-manager/main loc]]
         [:div.btn-group [save/main loc]]
         [:div.btn-group [exporttable/exporttable loc]]

--- a/src/im_tables/views/dashboard/manager/filters/main.cljs
+++ b/src/im_tables/views/dashboard/manager/filters/main.cljs
@@ -39,9 +39,11 @@
                 [:option {:value path}
                  (str/join " » " (path/display-name @model path))]))
         [:button.btn.btn-info.constraint-add
-         {:on-click #(dispatch [:filters/add-constraint loc {:path @!path
-                                                             :op "="
-                                                             :value nil}])
+         {:on-click #(when-let [path @!path]
+                       (dispatch [:main/fetch-possible-values loc path])
+                       (dispatch [:filters/add-constraint loc {:path path
+                                                               :op "="
+                                                               :value nil}]))
           :type "button"}
          [:i.fa.fa-plus]]]])))
 

--- a/src/im_tables/views/dashboard/manager/filters/main.cljs
+++ b/src/im_tables/views/dashboard/manager/filters/main.cljs
@@ -1,0 +1,76 @@
+(ns im-tables.views.dashboard.manager.filters.main
+  (:require [re-frame.core :refer [subscribe dispatch]]
+            [imcljs.path :as path]
+            [oops.core :refer [oget]]
+            [im-tables.views.table.head.controls :as controls]))
+
+(defn join-with-arrows
+  "Make a friendly HTML path name: Gene >> Data Sets >> Publications"
+  [v]
+  (->> v
+       (map (fn [n] [:span n]))
+       (interpose [:span [:i.fa.fa-angle-double-right.fa-fw]])))
+
+(defn constraint [loc]
+  (let [model (subscribe [:assets/model loc])]
+    (fn [loc {:keys [path op value code] :as const}]
+      [:li.list-group-item.filter-item
+       (-> [:div.filter-name]
+           (into (join-with-arrows (path/display-name @model path)))
+           (conj [:span.text-muted (str " (" code ")")]))
+       [controls/constraint loc path const]])))
+
+(defn constraint-form [loc]
+  (into [:ul.list-group.filter-manager]
+        (for [const @(subscribe [:filter-manager/filters loc])]
+          ^{:key (:code const)}
+          [constraint loc const])))
+
+(defn constraint-logic [loc]
+  (let [constraint-logic @(subscribe [:filter-manager/constraint-logic loc])
+        on-change #(dispatch [:filter-manager/change-constraint loc
+                              (oget % :target :value)])]
+    [:div.form
+     [:div.form-group
+      [:label "Constraint Logic"]
+      [:input.form-control.input-md
+       {:value constraint-logic
+        :on-change on-change}]]]))
+
+(defn modal-body [loc]
+  [:div
+   [constraint-form loc]
+   [constraint-logic loc]])
+
+(defn modal-footer [loc]
+  [:div.btn-toolbar.pull-right
+   [:button.btn.btn-default
+    {:on-click #(dispatch [:modal/close loc])}
+    "Cancel"]
+   [:button.btn.btn-success
+    {:on-click (fn []
+                 ; Apply the changes
+                 (dispatch [:filters/save-changes loc])
+                 ; Close the modal by clearing the markup from app-db
+                 (dispatch [:modal/close loc]))}
+    "Apply Changes"]])
+
+(defn build-modal [loc]
+  {:header [:h3 "Manage Filters"]
+   :body [modal-body loc]
+   :footer [modal-footer loc]})
+
+(defn main [loc]
+  [:div
+   [:div.btn-group
+    [:button.btn.btn-default
+     {:on-click (fn []
+                  ; Reset temp query
+                  (dispatch [:main/set-temp-query loc])
+                  ; Fetch possible values for all filters present
+                  (doseq [view (->> @(subscribe [:filter-manager/filters loc])
+                                    (map :path))]
+                    (dispatch [:main/fetch-possible-values loc view]))
+                  ; Build the modal markup and send it to app-db
+                  (dispatch [:modal/open loc (build-modal loc)]))}
+     [:i.fa.fa-filter] " Manage Filters"]]])

--- a/src/im_tables/views/table/body/main.cljs
+++ b/src/im_tables/views/table/body/main.cljs
@@ -110,18 +110,22 @@
                          :data-content (when (not-empty item-details)
                                          (->html (summary-table item-details)))}
 
-               [:a {:href link
-                    :on-click (fn []
-                                (when (and on-click value)
-                                  (do
-                                    ; Call the provided on-click
-                                    (on-click link)
-                                    ; Side effect!!
-                                    ; Destroy the popover in case the table is embedded in an SPA
-                                    ; otherwise it will stick after page routes
-                                    (-> @pop-el js/$
-                                        (ocall :find "[data-trigger='hover']")
-                                        (ocall :popover "destroy")))))}
+               [:a (merge
+                    {:on-click (fn []
+                                 (when (and on-click value)
+                                   (do
+                                     ; Call the provided on-click
+                                     (on-click link)
+                                     ; Side effect!!
+                                     ; Destroy the popover in case the table is embedded in an SPA
+                                     ; otherwise it will stick after page routes
+                                     (-> @pop-el js/$
+                                         (ocall :find "[data-trigger='hover']")
+                                         (ocall :popover "destroy")))))}
+                    ;; URL is incomplete until summary has been fetched and
+                    ;; `:value` key added, so avoid pointing to wrong URL.
+                    (when (contains? item-details :value)
+                      {:href link}))
                 (or value [no-value])]]]))]))))
 
 (defn table-row [loc row]

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -39,6 +39,7 @@
       error         [error/failure loc error]
       (seq results) (into [:<>] children)
       successful?   [error/no-results loc]
+      ;; Usually means a query is in progress (ie. loading case).
       (nil? res)    nil
       ;; The else case shouldn't occur, but we leave it just in case!
       :else         [error/failure loc (response->error res)])))

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -5,7 +5,8 @@
             [im-tables.views.table.body.main :as table-body]
             [im-tables.views.dashboard.main :as dashboard]
             [im-tables.views.table.error :as error]
-            [imcljs.query :as q]))
+            [imcljs.query :as q]
+            [im-tables.utils :refer [response->error]]))
 
 (defn table-head [loc]
   (let [dragging-item (subscribe [:style/dragging-item loc])
@@ -32,14 +33,14 @@
   Note that `res` might not hold the latest response if it failed, as in this
   case the `on-failure` event would fire instead."
   [loc {:keys [results success] :as res} & children]
-  (let [error @(subscribe [:main/error loc])
-        res (or (:response error) res)]
+  (let [error @(subscribe [:main/error loc])]
     (cond
-      error         [error/failure loc res]
+      error         [error/failure loc error]
       (seq results) children
-      success       [error/no-results loc res]
+      success       [error/no-results loc]
       (nil? res)    nil
-      :else         [error/failure loc res])))
+      ;; The else case shouldn't occur, but we leave it just in case!
+      :else         [error/failure loc (response->error res)])))
 
 (defn main [loc
             {:keys [results views] :as res}

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -36,7 +36,7 @@
   (let [error @(subscribe [:main/error loc])]
     (cond
       error         [error/failure loc error]
-      (seq results) children
+      (seq results) (into [:<>] children)
       success       [error/no-results loc]
       (nil? res)    nil
       ;; The else case shouldn't occur, but we leave it just in case!

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -28,9 +28,12 @@
                                    :view h}]))))])))
 
 (defn handle-states
-  "Depending on the response, other states may be displayed instead of children."
+  "Depending on the response, other states may be displayed instead of children.
+  Note that `res` might not hold the latest response if it failed, as in this
+  case the `on-failure` event would fire instead."
   [loc {:keys [results success] :as res} & children]
-  (let [error @(subscribe [:main/error loc])]
+  (let [error @(subscribe [:main/error loc])
+        res (or (:response error) res)]
     (cond
       error         [error/failure loc res]
       (seq results) children

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -30,11 +30,13 @@
 (defn handle-states
   "Depending on the response, other states may be displayed instead of children."
   [loc {:keys [results success] :as res} & children]
-  (cond
-    (seq results) children
-    success       [error/no-results loc res]
-    (nil? res)    nil
-    :else         [error/failure loc res]))
+  (let [error @(subscribe [:main/error loc])]
+    (cond
+      error         [error/failure loc res]
+      (seq results) children
+      success       [error/no-results loc res]
+      (nil? res)    nil
+      :else         [error/failure loc res])))
 
 (defn main [loc
             {:keys [results views] :as res}

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -32,12 +32,13 @@
   "Depending on the response, other states may be displayed instead of children.
   Note that `res` might not hold the latest response if it failed, as in this
   case the `on-failure` event would fire instead."
-  [loc {:keys [results success] :as res} & children]
-  (let [error @(subscribe [:main/error loc])]
+  [loc {:keys [results success wasSuccessful] :as res} & children]
+  (let [error @(subscribe [:main/error loc])
+        successful? (or success wasSuccessful)]
     (cond
       error         [error/failure loc error]
       (seq results) (into [:<>] children)
-      success       [error/no-results loc]
+      successful?   [error/no-results loc]
       (nil? res)    nil
       ;; The else case shouldn't occur, but we leave it just in case!
       :else         [error/failure loc (response->error res)])))

--- a/src/im_tables/views/table/core.cljs
+++ b/src/im_tables/views/table/core.cljs
@@ -32,7 +32,7 @@
         dragging-over (subscribe [:style/dragging-over loc])
         collapsed-views (subscribe [:query-response/views-collapsed-by-joins loc])]
     (fn [loc {:keys [results views]} {:keys [limit start] :or {limit 10 start 0}}]
-      [:div.relative
+      [:div.table-container
        [:table.table.table-condensed.table-bordered.table-striped
         [table-head loc views]
         (into [:tbody]

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -58,7 +58,7 @@ ERROR: " query-error)))))
            query-xml query-error]}]
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " Invalid query"]
-   [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. The easiest way to do this would be to return to the query builder (using your browser's back button) but you can also fix it using the controls above."]
+   [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. If you built this query with the " [:em "query builder"] " you can return to it using your browser's back button. If you have made changes to the query using the table controls, you can " [:em "undo"] " with the button above. You can also use the " [:em "reset"] " button below to revert all changes done."]
    [:p "If you did not make this query (i.e. it's a public list, template or part of a report page) or you believe there is something wrong on the server end, please use the button below to send an email with a pre-filled bug report to the maintainers."]
    [:div.button-group
     [:button.btn.btn-default
@@ -71,6 +71,10 @@ ERROR: " query-error)))))
       :on-click toggle-error
       :class (when show-error? "active")}
      [:i.fa.fa-bug] " Show error"]
+    [:button.btn.btn-info
+     {:type "button"
+      :on-click #(dispatch [:im-tables/restart loc])}
+     [:i.fa.fa-refresh] " Reset"]
     [:a.btn.btn-primary.pull-right
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]
@@ -89,6 +93,7 @@ ERROR: " query-error)))))
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " Server error"]
    [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+   [:p "Use the " [:em "retry"] " button below to attempt the query again."]
    [:div.button-group
     (when (not-empty query-xml)
       [:button.btn.btn-default
@@ -117,6 +122,7 @@ ERROR: " query-error)))))
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " im-tables crashed"]
    [:p "Something unexpected happened that im-tables wasn't able to handle. If you have a moment, we would appreciate it if you used the button below to send an email with a pre-filled bug report to the maintainers. Any description of what you were doing before this happened would be very helpful."]
+   [:p "Use the " [:em "reset"] " button below to restore the table's initial state."]
    [:div.button-group
     (when (not-empty error)
       [:button.btn.btn-default
@@ -127,7 +133,7 @@ ERROR: " query-error)))))
     [:button.btn.btn-info
      {:type "button"
       :on-click clear-error!}
-     [:i.fa.fa-refresh] " Restart"]
+     [:i.fa.fa-refresh] " Reset"]
     [:a.btn.btn-primary.pull-right
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -83,11 +83,12 @@ ERROR: " query-error)))))
    [:h2 [:i.fa.fa-bug] " Server error"]
    [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
    [:div.button-group
-    [:button.btn.btn-default
-     {:type "button"
-      :on-click toggle-query
-      :class (when show-query? "active")}
-     [:i.fa.fa-code] " Show query"]
+    (when (not-empty query-xml)
+      [:button.btn.btn-default
+       {:type "button"
+        :on-click toggle-query
+        :class (when show-query? "active")}
+       [:i.fa.fa-code] " Show query"])
     [:button.btn.btn-info
      {:type "button"
       :on-click #(dispatch [:main/retry-failure loc])}
@@ -108,19 +109,19 @@ ERROR: " query-error)))))
             mailto (mailto-string loc query-xml query-error)
             toggle-query #(swap! show-query not)
             toggle-error #(swap! show-error not)]
-       (if query-error
-          [query-failure
-           {:loc loc
-            :show-query? @show-query
-            :show-error? @show-error
-            :toggle-query toggle-query
-            :toggle-error toggle-error
-            :mailto mailto
-            :query-xml query-xml
-            :query-error query-error}]
-          [server-failure
-           {:loc loc
-            :show-query? @show-query
-            :toggle-query toggle-query
-            :mailto mailto
-            :query-xml query-xml}])))))
+        (if query-error
+           [query-failure
+            {:loc loc
+             :show-query? @show-query
+             :show-error? @show-error
+             :toggle-query toggle-query
+             :toggle-error toggle-error
+             :mailto mailto
+             :query-xml query-xml
+             :query-error query-error}]
+           [server-failure
+            {:loc loc
+             :show-query? @show-query
+             :toggle-query toggle-query
+             :mailto mailto
+             :query-xml query-xml}])))))

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -38,7 +38,7 @@ ERROR: " query-error)))))
 (defn no-results [loc]
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h4 "No results"]
-   [:p "You can use the buttons above to adjust your " [:em "filters"] " or " [:em "undo"] " the last change."]])
+   [:p "Your query produced no results. You can use the buttons above to adjust your " [:em "filters"] " or " [:em "undo"] " the last change."]])
 
 (defn code-block [loc code-string]
   (let [!code (atom nil)]
@@ -60,8 +60,8 @@ ERROR: " query-error)))))
            query-xml query-error]}]
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " Invalid query"]
-   [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. If you built this query with the " [:em "query builder"] " you can return to it using your browser's back button. If you have made changes to the query using the table controls, you can " [:em "undo"] " with the button above. You can also use the " [:em "reset"] " button below to revert all changes done."]
-   [:p "If you did not make this query (i.e. it's a public list, template or part of a report page) or you believe there is something wrong on the server end, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+   [:p "There is something wrong with your query. Please correct it by going back to the " [:em "query builder"] ". If you have modified the query using the table controls, you can " [:em "undo"] " with the button above. You can also use the " [:em "Reset"] " button below to revert all changes done."]
+   [:p "If you did not make this query (i.e. it's a public list, template or part of a report page) or you believe there is something wrong on the server end, please send a pre-filled bug report by clicking the button below."]
    [:div.button-group
     [:button.btn.btn-default
      {:type "button"
@@ -94,8 +94,8 @@ ERROR: " query-error)))))
            query-xml]}]
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " Server error"]
-   [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
-   [:p "Use the " [:em "retry"] " button below to attempt the query again."]
+   [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please send a pre-filled bug report by clicking the button below."]
+   [:p "Use the " [:em "Retry"] " button below to attempt the query again."]
    [:div.button-group
     (when (not-empty query-xml)
       [:button.btn.btn-default
@@ -122,9 +122,9 @@ ERROR: " query-error)))))
            error
            clear-error!]}]
   [:div.alert.alert-warning.table-error {:role "alert"}
-   [:h2 [:i.fa.fa-bug] " im-tables crashed"]
-   [:p "Something unexpected happened that im-tables wasn't able to handle. If you have a moment, we would appreciate it if you used the button below to send an email with a pre-filled bug report to the maintainers. Any description of what you were doing before this happened would be very helpful."]
-   [:p "Use the " [:em "reset"] " button below to restore the table's initial state."]
+   [:h2 [:i.fa.fa-bug] " Client error"]
+   [:p "There was an error in handling your request. Please send a pre-filled bug report by clicking the button below. Any description of what you were doing before this happened would be very helpful."]
+   [:p "Use the " [:em "Reset"] " button below to restore the table's initial state."]
    [:div.button-group
     (when (not-empty error)
       [:button.btn.btn-default

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -34,8 +34,9 @@ QUERY: " query-xml "
 ERROR: " query-error)))))
 
 (defn no-results [loc]
-  [:div.alert.alert-info {:role "alert"}
-   [:h2 "No results"]])
+  [:div.alert.alert-warning.table-error {:role "alert"}
+   [:h4 "No results"]
+   [:p "You can use the buttons above to adjust your " [:em "filters"] " or " [:em "undo"] " the last change."]])
 
 (defn code-block [loc code-string]
   (let [!code (atom nil)]

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -1,5 +1,5 @@
 (ns im-tables.views.table.error
-  (:require [re-frame.core :refer [subscribe]]
+  (:require [re-frame.core :refer [subscribe dispatch]]
             [reagent.core :as reagent]
             [imcljs.query :refer [->xml]]
             [oops.core :refer [ocall oget]]
@@ -42,47 +42,85 @@ ERROR: " query-error)))))
                          {:ref #(reset! !code %)}
                          code-string])})))
 
+(defn query-failure
+  "Failure message for invalid query."
+  [{:keys [loc
+           show-query? show-error?
+           toggle-query toggle-error
+           mailto
+           query-xml query-error]}]
+  [:div.alert.alert-warning.table-error {:role "alert"}
+   [:h2 [:i.fa.fa-bug] " Invalid query"]
+   [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. The easiest way to do this would be to return to the query builder (using your browser's back button) but you can also fix it using the controls above."]
+   [:p "If you did not make this query (i.e. it's a public list, template or part of a report page) or you believe there is something wrong on the server end, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+   [:div.button-group
+    [:button.btn.btn-default
+     {:type "button"
+      :on-click toggle-query
+      :class (when show-query? "active")}
+     [:i.fa.fa-code] " Show query"]
+    [:button.btn.btn-default
+     {:type "button"
+      :on-click toggle-error
+      :class (when show-error? "active")}
+     [:i.fa.fa-bug] " Show error"]
+    [:a.btn.btn-primary.pull-right
+     {:href mailto}
+     [:i.fa.fa-envelope] " Send a bug report"]]
+   (when show-query?
+     [:pre.well [code-block loc query-xml]])
+   (when show-error?
+     [:pre.well.text-danger query-error])])
+
+(defn server-failure
+  "Failure message for server error."
+  [{:keys [loc
+           show-query?
+           toggle-query
+           mailto
+           query-xml]}]
+  [:div.alert.alert-warning.table-error {:role "alert"}
+   [:h2 [:i.fa.fa-bug] " Server error"]
+   [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+   [:div.button-group
+    [:button.btn.btn-default
+     {:type "button"
+      :on-click toggle-query
+      :class (when show-query? "active")}
+     [:i.fa.fa-code] " Show query"]
+    [:button.btn.btn-info
+     {:type "button"
+      :on-click #(dispatch [:main/retry-failure loc])}
+     [:i.fa.fa-refresh] " Retry"]
+    [:a.btn.btn-primary.pull-right
+     {:href mailto}
+     [:i.fa.fa-envelope] " Send a bug report"]]
+   (when show-query?
+     [:pre.well [code-block loc query-xml]])])
+
 (defn failure [loc res]
   (let [show-query (reagent/atom false)
         show-error (reagent/atom false)]
     (fn [loc res]
       (let [model @(subscribe [:assets/model loc])
-            query-xml (->xml model @(subscribe [:main/query loc]))
-            query-error (get-in res [:body :error])]
-        [:div.alert.alert-warning.table-error {:role "alert"}
-         (if query-error
-           [:<>
-            [:h2 [:i.fa.fa-bug] " Invalid query"]
-            [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. If you believe there is something wrong on the server end, please use the button below to send an email with a pre-filled bug report to the maintainers."]
-            [:div.button-group
-             [:button.btn.btn-default
-              {:type "button"
-               :on-click #(swap! show-query not)
-               :class (when @show-query "active")}
-              [:i.fa.fa-code] " Show query"]
-             [:button.btn.btn-default
-              {:type "button"
-               :on-click #(swap! show-error not)
-               :class (when @show-error "active")}
-              [:i.fa.fa-bug] " Show error"]
-             [:a.btn.btn-primary.pull-right
-              {:href (mailto-string loc query-xml query-error)}
-              [:i.fa.fa-envelope] " Send a bug report"]]
-            (when @show-query
-              [:pre.well [code-block loc query-xml]])
-            (when @show-error
-              [:pre.well.text-danger query-error])]
-           [:<>
-            [:h2 [:i.fa.fa-bug] " Server error"]
-            [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
-            [:div.button-group
-             [:button.btn.btn-default
-              {:type "button"
-               :on-click #(swap! show-query not)
-               :class (when @show-query "active")}
-              [:i.fa.fa-code] " Show query"]
-             [:a.btn.btn-primary.pull-right
-              {:href (mailto-string loc query-xml query-error)}
-              [:i.fa.fa-envelope] " Send a bug report"]]
-            (when @show-query
-              [:pre.well [code-block loc query-xml]])])]))))
+            query-xml (when model (->xml model @(subscribe [:main/query loc])))
+            query-error (get-in res [:body :error])
+            mailto (mailto-string loc query-xml query-error)
+            toggle-query #(swap! show-query not)
+            toggle-error #(swap! show-error not)]
+       (if query-error
+          [query-failure
+           {:loc loc
+            :show-query? @show-query
+            :show-error? @show-error
+            :toggle-query toggle-query
+            :toggle-error toggle-error
+            :mailto mailto
+            :query-xml query-xml
+            :query-error query-error}]
+          [server-failure
+           {:loc loc
+            :show-query? @show-query
+            :toggle-query toggle-query
+            :mailto mailto
+            :query-xml query-xml}])))))

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -1,0 +1,88 @@
+(ns im-tables.views.table.error
+  (:require [re-frame.core :refer [subscribe]]
+            [reagent.core :as reagent]
+            [imcljs.query :refer [->xml]]
+            [oops.core :refer [ocall oget]]
+            [cljs-time.core :as time]
+            [cljs-time.format :refer [unparse formatters]]
+            [goog.string :as gstring]))
+
+(defn mailto-string [loc query-xml query-error]
+  (let [maintainer-email (get-in @(subscribe [:settings/settings loc])
+                                 [:mine :maintainerEmail]
+                                 "info@intermine.org")
+        current-url (oget js/window :location :href)
+        service-url (:root @(subscribe [:assets/service loc]))
+        current-date (unparse (formatters :rfc822) (time/now))]
+    (str "mailto:" maintainer-email
+         "?subject=" (gstring/urlEncode "[IMTABLES] - Error running query")
+         "&body=" (gstring/urlEncode
+                    (str "We encountered an error running a query from an embedded result table.
+
+page: " current-url "
+service: " service-url "
+date: " current-date "
+-------------------------------
+QUERY: " query-xml "
+-------------------------------
+ERROR: " query-error)))))
+
+(defn no-results [loc res]
+  [:div.alert.alert-info {:role "alert"}
+   [:h2 "No results"]])
+
+(defn code-block [loc code-string]
+  (let [!code (atom nil)]
+    (reagent/create-class
+     {:component-did-mount (fn [_]
+                             (when-let [code-elem @!code]
+                               (ocall js/hljs :highlightBlock code-elem)))
+      :reagent-render (fn [loc code-string]
+                        [:code.language-xml
+                         {:ref #(reset! !code %)}
+                         code-string])})))
+
+(defn failure [loc res]
+  (let [show-query (reagent/atom false)
+        show-error (reagent/atom false)]
+    (fn [loc res]
+      (let [model @(subscribe [:assets/model loc])
+            query-xml (->xml model @(subscribe [:main/query loc]))
+            query-error (get-in res [:body :error])]
+        [:div.alert.alert-warning.table-error {:role "alert"}
+         (if query-error
+           [:<>
+            [:h2 [:i.fa.fa-bug] " Invalid query"]
+            [:p "The server response indicates that there is something wrong with the query XML. You will likely have to modify the query to fix this error. If you believe there is something wrong on the server end, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+            [:div.button-group
+             [:button.btn.btn-default
+              {:type "button"
+               :on-click #(swap! show-query not)
+               :class (when @show-query "active")}
+              [:i.fa.fa-code] " Show query"]
+             [:button.btn.btn-default
+              {:type "button"
+               :on-click #(swap! show-error not)
+               :class (when @show-error "active")}
+              [:i.fa.fa-bug] " Show error"]
+             [:a.btn.btn-primary.pull-right
+              {:href (mailto-string loc query-xml query-error)}
+              [:i.fa.fa-envelope] " Send a bug report"]]
+            (when @show-query
+              [:pre.well [code-block loc query-xml]])
+            (when @show-error
+              [:pre.well.text-danger query-error])]
+           [:<>
+            [:h2 [:i.fa.fa-bug] " Server error"]
+            [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please use the button below to send an email with a pre-filled bug report to the maintainers."]
+            [:div.button-group
+             [:button.btn.btn-default
+              {:type "button"
+               :on-click #(swap! show-query not)
+               :class (when @show-query "active")}
+              [:i.fa.fa-code] " Show query"]
+             [:a.btn.btn-primary.pull-right
+              {:href (mailto-string loc query-xml query-error)}
+              [:i.fa.fa-envelope] " Send a bug report"]]
+            (when @show-query
+              [:pre.well [code-block loc query-xml]])])]))))

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -63,16 +63,18 @@ ERROR: " query-error)))))
    [:p "There is something wrong with your query. Please correct it by going back to the " [:em "query builder"] ". If you have modified the query using the table controls, you can " [:em "undo"] " with the button above. You can also use the " [:em "Reset"] " button below to revert all changes done."]
    [:p "If you did not make this query (i.e. it's a public list, template or part of a report page) or you believe there is something wrong on the server end, please send a pre-filled bug report by clicking the button below."]
    [:div.button-group
-    [:button.btn.btn-default
-     {:type "button"
-      :on-click toggle-query
-      :class (when show-query? "active")}
-     [:i.fa.fa-code] " Show query"]
-    [:button.btn.btn-default
-     {:type "button"
-      :on-click toggle-error
-      :class (when show-error? "active")}
-     [:i.fa.fa-bug] " Show error"]
+    (when (not-empty query-xml)
+      [:button.btn.btn-default
+       {:type "button"
+        :on-click toggle-query
+        :class (when show-query? "active")}
+       [:i.fa.fa-code] " Show query"])
+    (when (not-empty query-error)
+      [:button.btn.btn-default
+       {:type "button"
+        :on-click toggle-error
+        :class (when show-error? "active")}
+       [:i.fa.fa-bug] " Show error"])
     [:button.btn.btn-info
      {:type "button"
       :on-click #(dispatch [:im-tables/restart loc])}
@@ -89,9 +91,12 @@ ERROR: " query-error)))))
   "Failure message for server error."
   [{:keys [loc
            show-query?
+           show-error?
            toggle-query
+           toggle-error
            mailto
-           query-xml]}]
+           query-xml
+           error]}]
   [:div.alert.alert-warning.table-error {:role "alert"}
    [:h2 [:i.fa.fa-bug] " Server error"]
    [:p "You have received an invalid response from the server. This can be a sign of network issues or problems with the server itself. If the issue persists, please send a pre-filled bug report by clicking the button below."]
@@ -103,6 +108,12 @@ ERROR: " query-error)))))
         :on-click toggle-query
         :class (when show-query? "active")}
        [:i.fa.fa-code] " Show query"])
+    (when (not-empty error)
+      [:button.btn.btn-default
+       {:type "button"
+        :on-click toggle-error
+        :class (when show-error? "active")}
+       [:i.fa.fa-code] " Show error"])
     [:button.btn.btn-info
      {:type "button"
       :on-click #(dispatch [:main/retry-failure loc])}
@@ -111,7 +122,9 @@ ERROR: " query-error)))))
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]
    (when show-query?
-     [:pre.well [code-block loc query-xml]])])
+     [:pre.well [code-block loc query-xml]])
+   (when show-error?
+     [:pre.well.text-danger error])])
 
 (defn boundary-failure
   "Failure message when catching uncaught error with Error Boundary."
@@ -163,7 +176,9 @@ ERROR: " query-error)))))
           :network [server-failure
                     {:loc loc
                      :show-query? @show-query
+                     :show-error? @show-error
                      :toggle-query toggle-query
+                     :toggle-error toggle-error
                      :mailto (mailto-string loc
                                             ;; Fallback values in case we're missing stuff.
                                             (or query-xml
@@ -171,7 +186,8 @@ ERROR: " query-error)))))
                                             (or (:message error)
                                                 (clj->json (:response error))
                                                 "Request timed out"))
-                     :query-xml query-xml}]
+                     :query-xml query-xml
+                     :error (:message error)}]
           :boundary (let [error-string (str (:error error)
                                             \newline
                                             (or (oget (:info error) :componentStack)

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -25,7 +25,7 @@
          (when cc-support?
            (str "&cc=" support-email))
          "&body=" (gstring/urlEncode
-                    (str "We encountered an error running a query from an embedded result table.
+                   (str "We encountered an error running a query from an embedded result table.
 
 page: " current-url "
 service: " service-url "

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -287,18 +287,19 @@
            {:value (:op @state)
             :on-change on-constraint-change
             :data-type type}]]
-         [constraint-input
-          :model @model
-          :path view
-          :value (or (:value @state)
-                     (:values @state))
-          :typeahead? true
-          :on-change on-change
-          :on-blur on-change
-          :type type
-          :possible-values @possible-values
-          :disabled false
-          :op (:op @state)]]))))
+         [:div.constraint-input
+          [constraint-input
+           :model @model
+           :path view
+           :value (or (:value @state)
+                      (:values @state))
+           :typeahead? true
+           :on-change on-change
+           :on-blur on-change
+           :type type
+           :possible-values @possible-values
+           :disabled false
+           :op (:op @state)]]]))))
 
 (defn constraint [loc view]
   (let [possible-values (subscribe [:selection/possible-values loc view])
@@ -329,7 +330,7 @@
            :possible-values @possible-values
            :disabled false
            :op op]]
-         [:button.btn.btn-danger
+         [:button.btn.btn-danger.constraint-delete
           {:on-click (fn [] (dispatch [:filters/remove-constraint loc const]))
            :type "button"} [:i.fa.fa-times]]]))))
 
@@ -341,8 +342,7 @@
                                 (filter (partial constraint-has-path? view)
                                         (:where @query)))
             dropdown (reagent/current-component)]
-        [:form.form.filter-view {:style {:padding "5px"}
-                                 :on-submit (fn [e]
+        [:form.form.filter-view {:on-submit (fn [e]
                                               (ocall e "preventDefault")
                                               (force-close dropdown)
                                               (dispatch [:filters/save-changes loc]))}

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -255,7 +255,7 @@
   (cond-> constraint
     (contains? new-const :op)
     (as-> const
-      (assoc const :op new-op)
+          (assoc const :op new-op)
       (case [(op-type old-op) (op-type new-op)]
         [:single :multi] (-> const
                              (set/rename-keys {:value :values})
@@ -266,9 +266,9 @@
         const))
     (contains? new-const :value)
     (as-> const
-      (case (op-type (:op const))
-        :single (assoc const :value new-value)
-        :multi (assoc const :values new-value)))))
+          (case (op-type (:op const))
+            :single (assoc const :value new-value)
+            :multi (assoc const :values new-value)))))
 
 (defn blank-constraint [loc view]
   (let [possible-values (subscribe [:selection/possible-values loc view])
@@ -576,14 +576,14 @@
                     ;; has actually changed before rerunning the query
                    (dispatch [:filters/save-changes loc])))
                 (on-event
-                  "show.bs.dropdown"
-                  (fn []
-                    (when (nil? @possible-values)
-                      (dispatch [:main/fetch-possible-values loc view]))
-                    (when-let [dropdown @!dropdown-menu]
-                      (when-let [toggle @!filter-dropdown]
-                        (place-below! dropdown toggle
-                                      :right? right?))))))}
+                 "show.bs.dropdown"
+                 (fn []
+                   (when (nil? @possible-values)
+                     (dispatch [:main/fetch-possible-values loc view]))
+                   (when-let [dropdown @!dropdown-menu]
+                     (when-let [toggle @!filter-dropdown]
+                       (place-below! dropdown toggle
+                                     :right? right?))))))}
          [:i.fa.fa-filter.dropdown-toggle.filter-icon
           {:on-click (fn [] (dispatch [:main/set-temp-query loc]))
            :data-toggle "dropdown"

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -17,52 +17,40 @@
 
 (def operators [{:op "LOOKUP"
                  :label "Lookup"
-                 :applies-to #{nil}
-                 :multiple-values? false}
+                 :applies-to #{nil}}
                 {:op "IN"
                  :label "In list"
-                 :applies-to #{nil}
-                 :multiple-values? false}
+                 :applies-to #{nil}}
                 {:op "NOT IN"
                  :label "Not in list"
-                 :applies-to #{nil}
-                 :multiple-values? false}
+                 :applies-to #{nil}}
                 {:op "="
                  :label "="
-                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op "!="
                  :label "!="
-                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op "<"
                  :label "<"
-                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op "<="
                  :label "<="
-                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op ">"
                  :label ">"
-                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op ">="
                  :label ">="
-                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}}
                 {:op "CONTAINS"
                  :label "Contains"
-                 :applies-to #{"java.lang.String"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.String"}}
                 {:op "LIKE"
                  :label "Like"
-                 :applies-to #{"java.lang.String"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.String"}}
                 {:op "NOT LIKE"
                  :label "Not like"
-                 :applies-to #{"java.lang.String"}
-                 :multiple-values? false}
+                 :applies-to #{"java.lang.String"}}
                 {:op "ONE OF"
                  :label "One of"
                  :applies-to #{"java.lang.String"}
@@ -70,7 +58,15 @@
                 {:op "NONE OF"
                  :label "None of"
                  :applies-to #{"java.lang.String"}
-                 :multiple-values? true}])
+                 :multiple-values? true}
+                {:op "IS NULL"
+                 :label "Null"
+                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
+                 :no-value? true}
+                {:op "IS NOT NULL"
+                 :label "Not null"
+                 :applies-to #{"java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"}
+                 :no-value? true}])
 
 (defn filter-input []
   (fn [loc view val]
@@ -213,12 +209,18 @@
                                (on-blur (oget e :target :value))
                                (reset! focused? false)))}])))
 
+(def operators-no-value
+  (set (map :op (filter :no-value? operators))))
+
 (defn constraint-input
   "Returns the appropriate input component for the constraint operator."
   [& {:keys [model path value typeahead? on-change on-blur type
              possible-values disabled op]
       :as props}]
   (cond
+    (operators-no-value op)
+    nil
+
     (= type "java.util.Date")
     [date-constraint-input props]
 
@@ -365,7 +367,8 @@
             {:type "submit"
              :on-click (fn []
                          (when (or (not-empty (:value @blank-constraint-atom))
-                                   (not-empty (:values @blank-constraint-atom)))
+                                   (not-empty (:values @blank-constraint-atom))
+                                   (operators-no-value (:op @blank-constraint-atom)))
                            (dispatch
                             [:filters/add-constraint loc @blank-constraint-atom]
                             (reset! blank-constraint-atom {:path view :op "=" :value nil}))))

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -486,13 +486,13 @@
          [:div.main-view
           [histogram/main (:results @response)]
           [filter-input loc view @text-filter]
-          [:table.table.table-striped.table-condensed
+          [:table.table.table-striped.table-condensed.table-scrollable
            [:thead [:tr [:th
                          (if (empty? @selections)
                            [:span {:title "Select all"
                                    :on-click (fn [] (dispatch [:select/select-all loc view]))} [:i.fa.fa-check-square-o]]
                            [:span {:title "Deselect all"
-                                   :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])] [:th "Item"] [:th "Count"]]]
+                                   :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])] [:th.data-item "Item"] [:th "Count"]]]
            (into [:tbody]
                  (->> (filter (partial has-text? @text-filter) (:results @response))
                       (map (fn [{:keys [count item]}]
@@ -503,7 +503,7 @@
                                 {:on-change (fn [])
                                  :checked (contains? @selections item)
                                  :type "checkbox"}]]
-                              [:td (if item item [no-value])]
+                              [:td.data-item (if item item [no-value])]
                               [:td
                                [:div count]]]))))]]
          [:div.btn-toolbar.column-summary-toolbar

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -10,7 +10,9 @@
             [oops.core :refer [oget ocall ocall! oget+]]
             [im-tables.utils :refer [on-event pretty-number display-name]]
             [cljs-time.coerce :as time-coerce]
-            [cljs-time.format :as time-format]))
+            [cljs-time.format :as time-format]
+            [goog.dom :as gdom]
+            [goog.style :as gstyle]))
 
 (def css-transition-group
   (reagent/adapt-react-class js/ReactTransitionGroup.CSSTransitionGroup))
@@ -468,59 +470,80 @@
   (let [response (subscribe [:selection/response loc view])
         selections (subscribe [:selection/selections loc view])
         text-filter (subscribe [:selection/text-filter loc view])]
-    (reagent/create-class
-     {:component-will-mount
-      (fn [])
-      :component-will-update
-      (fn [])
-      :reagent-render
-      (fn [loc view]
-        (cond
-          (nil? @response)
-          [column-summary-thinking]
+    (fn [loc view local-state !dropdown]
+      (cond
+        (nil? @response)
+        [column-summary-thinking]
 
-          (false? @response)
-          [too-many-values]
+        (false? @response)
+        [too-many-values]
 
-          (contains? (first (:results @response)) :min)
-          [numerical-column-summary loc view (:results @response) local-state]
+        (contains? (first (:results @response)) :min)
+        [numerical-column-summary loc view (:results @response) local-state]
 
-          :else
-          [:form.form.column-summary
-           [column-summary-title loc view @response]
-           [:div.main-view
-            [histogram/main (:results @response)]
-            [filter-input loc view @text-filter]
-            [:table.table.table-striped.table-condensed
-             [:thead [:tr [:th
-                           (if (empty? @selections)
-                             [:span {:title "Select all"
-                                     :on-click (fn [] (dispatch [:select/select-all loc view]))} [:i.fa.fa-check-square-o]]
-                             [:span {:title "Deselect all"
-                                     :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])] [:th "Item"] [:th "Count"]]]
-             (into [:tbody]
-                   (->> (filter (partial has-text? @text-filter) (:results @response))
-                        (map (fn [{:keys [count item]}]
-                               [:tr.hoverable
-                                {:on-click (fn [e] (dispatch [:select/toggle-selection loc view item]))}
-                                [:td
-                                 [:input
-                                  {:on-change (fn [])
-                                   :checked (contains? @selections item)
-                                   :type "checkbox"}]]
-                                [:td (if item item [no-value])]
-                                [:td
-                                 [:div count]]]))))]]
-           [:div.btn-toolbar.column-summary-toolbar
-            [:button.btn.btn-primary
-             {:type "button"
-              :on-click (fn []
-                          (dispatch [:main/apply-summary-filter loc view])
-                          (when-let [el @!dropdown]
-                            (-> (js/$ el)
-                                (ocall! "dropdown" "toggle"))))}
-             [:i.fa.fa-filter]
-             (str " Filter")]]]))})))
+        :else
+        [:form.form.column-summary
+         [column-summary-title loc view @response]
+         [:div.main-view
+          [histogram/main (:results @response)]
+          [filter-input loc view @text-filter]
+          [:table.table.table-striped.table-condensed
+           [:thead [:tr [:th
+                         (if (empty? @selections)
+                           [:span {:title "Select all"
+                                   :on-click (fn [] (dispatch [:select/select-all loc view]))} [:i.fa.fa-check-square-o]]
+                           [:span {:title "Deselect all"
+                                   :on-click (fn [] (dispatch [:select/clear-selection loc view]))} [:i.fa.fa-square-o]])] [:th "Item"] [:th "Count"]]]
+           (into [:tbody]
+                 (->> (filter (partial has-text? @text-filter) (:results @response))
+                      (map (fn [{:keys [count item]}]
+                             [:tr.hoverable
+                              {:on-click (fn [e] (dispatch [:select/toggle-selection loc view item]))}
+                              [:td
+                               [:input
+                                {:on-change (fn [])
+                                 :checked (contains? @selections item)
+                                 :type "checkbox"}]]
+                              [:td (if item item [no-value])]
+                              [:td
+                               [:div count]]]))))]]
+         [:div.btn-toolbar.column-summary-toolbar
+          [:button.btn.btn-primary
+           {:type "button"
+            :on-click (fn []
+                        (dispatch [:main/apply-summary-filter loc view])
+                        (when-let [el @!dropdown]
+                          (-> (js/$ el)
+                              (ocall! "dropdown" "toggle"))))}
+           [:i.fa.fa-filter]
+           (str " Filter")]]]))))
+
+;; The 360 magic number used below is the minimum width for the column summary.
+;; Instead of updating the position of the dropdown when it's done loading, I
+;; went the simple route of guessing the position to be good enough. This means
+;; - when dropdown is on right half of screen, the loader is not correctly
+;;   aligned, but when it transitions to showing the data, it will be
+;;   - it will however not be if the width of the dropdown is greater
+;; - once the data is loaded, any subsequent dropdown opened will be aligned
+(defn place-below!
+  "Call with DOM elements to set the position styling of `below` such that it
+  is directly below the edge of `above`.
+  `right?` - position `below` using its top right corner (instead of top left).
+  `loading?` - when `right?` is true, we need to know the width of `below` to
+               position it correctly. This arg tells us that the width might
+               change when it's done loading, so we just guess instead."
+  [below above & {:keys [right? loading?]}]
+  (let [[above-w offset-y] ((juxt #(oget % :width) #(oget % :height))
+                            (gstyle/getSize above))
+        offset-x (if right?
+                   (* -1 (- (if loading?
+                              360
+                              (oget (gstyle/getSize below) :width))
+                            above-w))
+                   0)
+        pos (-> (gstyle/getClientPosition above)
+                (ocall :translate offset-x offset-y))]
+    (gstyle/setPosition below pos)))
 
 ;; Bootstrap and ReactJS don't always mix well. Components that make up
 ;; dropdown menus are only mounted (reactjs) once and then their visibility is
@@ -535,7 +558,9 @@
 (defn filter-dropdown-menu [loc view idx col-count]
   (let [possible-values (subscribe [:selection/possible-values loc view])
         query (subscribe [:main/query loc view])
-        blank-constraint-atom (reagent/atom {:path view :op "=" :value nil})]
+        blank-constraint-atom (reagent/atom {:path view :op "=" :value nil})
+        !filter-dropdown (atom nil)
+        !dropdown-menu (atom nil)]
     (fn [loc view idx col-count right?]
       (let [active-filters? (not-empty (filter (partial constraint-has-path? view) (:where @query)))]
         [:span.dropdown
@@ -553,16 +578,59 @@
                    (dispatch [:filters/save-changes loc])))
                 (on-event
                   "show.bs.dropdown"
-                  #(when (nil? @possible-values)
-                     (dispatch [:main/fetch-possible-values loc view]))))}
+                  (fn []
+                    (when (nil? @possible-values)
+                      (dispatch [:main/fetch-possible-values loc view]))
+                    (when-let [dropdown @!dropdown-menu]
+                      (when-let [toggle @!filter-dropdown]
+                        (place-below! dropdown toggle
+                                      :right? right?))))))}
          [:i.fa.fa-filter.dropdown-toggle.filter-icon
           {:on-click (fn [] (dispatch [:main/set-temp-query loc]))
            :data-toggle "dropdown"
            :class (cond active-filters? "active-filter")
-           :title (str "Filter " view " column")}]
+           :title (str "Filter " view " column")
+           :ref (fn [el] (reset! !filter-dropdown el))}]
          ; Crudely try to draw the dropdown near the middle of the page
          [:div.dropdown-menu
-          {:class (when right? "dropdown-right")} [filter-view loc view blank-constraint-atom]]]))))
+          {:ref (fn [el] (reset! !dropdown-menu el))}
+          [filter-view loc view blank-constraint-atom]]]))))
+
+(defn summary-dropdown-menu [loc view idx col-count]
+  (let [local-state (reagent/atom {})
+        !summary-dropdown (atom nil)
+        !dropdown-menu (atom nil)
+        response (subscribe [:selection/response loc view])]
+    (fn [loc view idx col-count right?]
+      [:span.dropdown
+       ;; Bind an event to clear the selected items when the dropdown
+       ;; closes. Why don't we just avoid state all together and pick up the
+       ;; checkbox values when the user clicks "Filter"? Because we still
+       ;; want to know what's selected (for instance, highlighting the
+       ;; histogram).
+       {:ref (comp
+              (on-event
+               "hide.bs.dropdown"
+               (fn []
+                 (reset! local-state {})
+                 (dispatch [:select/clear-selection loc view])))
+              (on-event
+               "show.bs.dropdown"
+               (fn []
+                 (when (nil? @response)
+                   (dispatch [:main/summarize-column loc view]))
+                 (when-let [dropdown @!dropdown-menu]
+                   (when-let [toggle @!summary-dropdown]
+                     (place-below! dropdown toggle
+                                   :right? right?
+                                   :loading? (nil? @response)))))))}
+       [:i.fa.fa-bar-chart.dropdown-toggle
+        {:title (str "Summarise " view " column")
+         :data-toggle "dropdown"
+         :ref (fn [el] (reset! !summary-dropdown el))}]
+       [:div.dropdown-menu
+        {:ref (fn [el] (reset! !dropdown-menu el))}
+        [column-summary loc view local-state !summary-dropdown]]])))
 
 (defn obj->clj [obj]
   (reduce (fn [total next-key]
@@ -574,13 +642,9 @@
     (> left (/ screen-width 2))))
 
 (defn toolbar []
-  (let [right? (reagent/atom false)
-        !summary-dropdown (atom nil)]
+  (let [right? (reagent/atom false)]
     (fn [loc view idx col-count]
-      (let [query           (subscribe [:main/temp-query loc view])
-            response        (subscribe [:selection/response loc view])
-            sort-direction  (subscribe [:ui/column-sort-direction loc view])
-            local-state     (reagent/atom {})]
+      (let [sort-direction  (subscribe [:ui/column-sort-direction loc view])]
         [:div.summary-toolbar
          {:ref (fn [e]
                  (when e (reset! right? (align-right? e))))}
@@ -595,26 +659,4 @@
           {:on-click (fn [] (dispatch [:main/remove-view loc view]))
            :title (str "Remove " view " column")}]
          [filter-dropdown-menu loc view idx col-count @right?]
-         [:span.dropdown
-          ;; Bind an event to clear the selected items when the dropdown
-          ;; closes. Why don't we just avoid state all together and pick up the
-          ;; checkbox values when the user clicks "Filter"? Because we still
-          ;; want to know what's selected (for instance, highlighting the
-          ;; histogram).
-          {:ref (comp
-                 (on-event
-                  "hide.bs.dropdown"
-                  (fn []
-                    (reset! local-state {})
-                    (dispatch [:select/clear-selection loc view])))
-                 (on-event
-                  "show.bs.dropdown"
-                  #(when (nil? @response)
-                     (dispatch [:main/summarize-column loc view]))))}
-          [:i.fa.fa-bar-chart.dropdown-toggle
-           {:data-toggle "dropdown"
-            :ref (fn [el] (reset! !summary-dropdown el))}]
-          [:div.dropdown-menu
-           {:title (str "Summarise " view " column")
-            :class (when @right? "dropdown-right")}
-           [column-summary loc view local-state !summary-dropdown]]]]))))
+         [summary-dropdown-menu loc view idx col-count @right?]]))))

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -1,6 +1,7 @@
 (ns im-tables.views.table.head.controls
   (:require [re-frame.core :refer [subscribe dispatch]]
             [reagent.core :as reagent]
+            [reagent.dom :as dom]
             [im-tables.views.graphs.histogram :as histogram]
             [im-tables.views.common :refer [no-value]]
             [imcljs.path :as path]
@@ -27,7 +28,7 @@
 (defn force-close
   "Force a dropdown to close "
   [component]
-  (-> (js/$ (reagent/dom-node component))
+  (-> (js/$ (dom/dom-node component))
       (ocall! "closest" ".dropdown-menu")
       (ocall! "parent")
       (ocall! "removeClass" "open")))

--- a/test/cljs/im_tables/core_test.cljs
+++ b/test/cljs/im_tables/core_test.cljs
@@ -9,7 +9,7 @@
 
 (use-fixtures :each utils/fixtures)
 
-(def im-config {:service {:root "beta.humanmine.org/beta"}
+(def im-config {:service {:root "http://localhost:9999/biotestmine"}
                 :query {:from "Gene"
                         :select ["symbol"
                                  "secondaryIdentifier"
@@ -47,7 +47,8 @@
         (testing "response can be sorted by column"
           (let [response @(rf/subscribe [:main/query-response loc])
                 result (get-in response [:results 0])]
-            (is (= "1" (->> result
-                            (filter #(= (:column %) "Gene.primaryIdentifier"))
-                            first
-                            :value)))))))))
+            (is (= "1396.pre-tRNA-Met-1"
+                   (->> result
+                        (filter #(= (:column %) "Gene.primaryIdentifier"))
+                        first
+                        :value)))))))))


### PR DESCRIPTION
Mostly a big blob of various improvements.

- Project setup
    - Update dependencies
    - Run tests against local biotestmine
    - Improve dev experience by not rebooting table on changes
    - Fix README code example
- Constraints
    - New searchable dropdown and calendar components
    - Filter constraint ops to those applicable to data type
    - Add IS NULL and IS NOT NULL
    - Filter manager for adding and modifying constraints and logic
- Interface
    - Handle overly wide tables by displaying scrollbar
    - Fix numerical column summary title pluralisation
    - Column summary scrollbar for tbody instead of entire body
    - Do not add href to cells until we are sure URL is complete
- Error handling
    - Views for No Results, Invalid Query, Server Error and Im-tables Crashed (error boundary)
    - Use async-flow for booting and handle invalid responses
    - Add save-list-failure event to be intercepted by BlueGenes

Some tips on triggering the error views, mostly for future reference.

* Invalid query: Add non-existant paths to query view vector in the `im-tables.views` config
* Server error: Rename service path to something not in use in the `im-tables.views` config (e.g. adding z to the end)
* im-tables crashed: Throw an error somewhere in the component tree `(throw (js/Error. "Whoops!"))`