### PR TITLE
Fix and improve histogram in numeric column summary

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -655,6 +655,7 @@
     .histo {
         background-color: @histogram-bg;
         display: flex;
+        align-items: flex-end;
         height: 75px;
         box-sizing: border-box;
         position: relative;

--- a/less/site.less
+++ b/less/site.less
@@ -652,32 +652,56 @@
         padding: 5px;
     }
 
-    .histo {
-        background-color: @histogram-bg;
-        display: flex;
-        align-items: flex-end;
-        height: 75px;
-        box-sizing: border-box;
-        position: relative;
-        border-bottom: 1px solid black;
-        .histo-bucket {
-            flex: 1 0;
-            &.full {
-                background-color: @histogram-bars;
-                border-left: 1px solid white;
-                border-right: 1px solid white;
+    .histo-container {
+        .histo {
+            background-color: @histogram-bg;
+            display: flex;
+            align-items: flex-end;
+            height: 75px;
+            box-sizing: border-box;
+            position: relative;
+            border-bottom: 1px solid black;
+            .histo-bucket {
+                flex: 1 0;
+                &.full {
+                    background-color: @histogram-bars;
+                    border-left: 1px solid white;
+                    border-right: 1px solid white;
+                }
+            }
+            .trimmer {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                background-color: orange;
+                opacity: 0.3;
+            }
+            .average {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                width: 2px;
+                background-color: red;
+                opacity: 0.75;
             }
         }
-        .trimmer {
-            position: absolute;
-            top: 0;
-            // left: 0;
-            bottom: 0;
-            // width: 100%;
-            background-color: orange;
-            opacity: 0.3;
+
+        .histo-x-label {
+            display: flex;
+            justify-content: space-between;
+            margin-top: @spacer/8;
+
+            span {
+                font-size: 12px;
+            }
+
+            span, button {
+                margin-left: @spacer/8;
+                margin-right: @spacer/8;
+            }
         }
     }
+
     .numerical-content-wrapper {
         padding: 10px;
     }

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -57,11 +57,11 @@
 
 (def covidmine-config
   {:service {:root "https://test.intermine.org/covidmine"}
-   :query {:from "Distribution"
+   :query {:from "Cases"
            :select ["date"
-                    "totalCases"
+                    "totalConfirmed"
                     "totalDeaths"
-                    "newCases"
+                    "newConfirmed"
                     "newDeaths"
                     "geoLocation.country"
                     "geoLocation.state"]}
@@ -100,7 +100,7 @@
 (def number-of-tables 1)
 (defn reboot-tables-fn []
   (dotimes [n number-of-tables]
-    (re-frame/dispatch-sync [:im-tables/load [:test :location n] covidmine-config])))
+    (re-frame/dispatch-sync [:im-tables/load [:test :location n] flymine-config])))
 
 (defn main-panel []
   (let [show? (r/atom true)]

--- a/src/im_tables/views/graphs/histogram.cljs
+++ b/src/im_tables/views/graphs/histogram.cljs
@@ -1,10 +1,19 @@
-(ns im-tables.views.graphs.histogram)
+(ns im-tables.views.graphs.histogram
+  (:require [reagent.core :as r]
+            [im-tables.utils :refer [pretty-number]]))
 
-(defn linear-scale [[r1-lower r1-upper] [r2-lower r2-upper]]
+(defn linear-scale [r1 r2]
   (fn [v]
-    (+ (/ (* (- v r1-lower) (- r2-upper r2-lower))
-          (- r1-upper r1-lower))
-       r2-lower)))
+    (* (/ v r1) r2)))
+
+(defn log-scale [r1 r2]
+  (fn [v]
+    (* (/ (Math/log v) (Math/log r1)) r2)))
+
+(defn scale [type r1 r2]
+  (case type
+    :linear (linear-scale r1 r2)
+    :log (log-scale r1 r2)))
 
 (defn datum
   "A single scaled bar for the histogram"
@@ -20,7 +29,7 @@
           unique-results (reduce (fn [new-set point] (conj new-set (:count point))) #{} points)
           only-one-count-result? (= (count unique-results) 1)
           show-graph? (not (or only-one-column? only-one-count-result?))
-          height-scale (linear-scale [0 (apply max (map :count points))] [0 50])]
+          height-scale (linear-scale (apply max (map :count points)) 50)]
       (if show-graph?
         (into [:div.graph.histogram]
               (map-indexed (fn [idx d]
@@ -31,12 +40,21 @@
               only-one-count-result?
               [:div.no-histogram [:i.fa.fa-bar-chart] " No histogram; all values occur exactly " (first unique-results) " time(s)"])))))
 
-(defn bucket [height-scale {:keys [count] :as data}]
+(defn bucket [height-scale {:keys [bucket min max buckets count] :as data}]
   [:div.histo-bucket
-   (merge
-    {:class (if data "full" "empty")}
-    (when (pos? count)
-      {:style {:height (str (height-scale count) "px")}}))])
+   {:title (when data
+             (let [base-amount (/ (- max min) buckets)
+                   low-interval (+ (* base-amount (dec bucket)) 364)
+                   high-interval (+ (* base-amount bucket) 364)]
+               (str (pretty-number low-interval) " to " (pretty-number high-interval)
+                    ": " count (if (> count 1) " values" " value"))))
+    :class (if data "full" "empty")
+    :style (when (number? count)
+             ;; Counts of 1 become 0 when scaled logarithmically. They're still
+             ;; relevant data points, so we make sure they're 1px tall.
+             {:height (str (let [scaled (height-scale count)]
+                             (if (zero? scaled) 1 scaled))
+                           "px")})}])
 
 (defn percent-of [min max number]
   (* 100 (/ (- number min) (- max min))))
@@ -45,17 +63,38 @@
 (def clj-max max)
 
 (defn numerical-histogram []
-  (fn [data-points trim]
-    (let [{:keys [buckets min max]} (first data-points)
-          {:keys [from to]} trim
-          by-bucket (group-by :bucket data-points)
-          height-scale (linear-scale [0 (apply clj-max (map :count data-points))] [0 75])]
-      [:div.histo
-       (when (or from to)
-         [:div.trimmer
-          {:style {:left (str (clj-max 0 (percent-of min max (or from min))) "%")
-                   :right (str (clj-min 100 (- 100 (percent-of min max (or to max)))) "%")}}])
-       (map (fn [bucket-number]
-              ^{:key bucket-number}
-              [bucket height-scale (-> bucket-number by-bucket first)])
-            (range 1 (inc buckets)))])))
+  (let [scale-y (r/atom :linear)]
+    (fn [data-points trim]
+      (let [{:keys [buckets min max average]} (first data-points)
+            {:keys [from to]} trim
+            by-bucket (group-by :bucket data-points)
+            height-scale (scale @scale-y (apply clj-max (map :count data-points)) 75)]
+        [:div.histo-container
+         [:div.histo
+          (when (or from to)
+            [:div.trimmer
+             {:style {:left (str (clj-max 0 (percent-of min max (or from min))) "%")
+                      :right (str (clj-min 100 (- 100 (percent-of min max (or to max)))) "%")}}])
+          [:div.average
+           {:title (str "Average: " (pretty-number average))
+            :style {:left (str (clj-max 0 (percent-of min max average)) "%")}}]
+          (map (fn [bucket-number]
+                 ^{:key bucket-number}
+                 [bucket height-scale (-> bucket-number by-bucket first)])
+               (range 1 (inc buckets)))]
+         [:div.histo-x-label
+          [:span (pretty-number min)]
+          [:div.histo-scale
+           [:button.btn.btn-default.btn-xs
+            {:type "button"
+             :class (when (= @scale-y :linear)
+                      "active")
+             :on-click #(reset! scale-y :linear)}
+            "linear"]
+           [:button.btn.btn-default.btn-xs
+            {:type "button"
+             :class (when (= @scale-y :log)
+                      "active")
+             :on-click #(reset! scale-y :log)}
+            "log"]]
+          [:span (pretty-number max)]]]))))

--- a/src/im_tables/views/graphs/histogram.cljs
+++ b/src/im_tables/views/graphs/histogram.cljs
@@ -24,12 +24,12 @@
       :title (str item ": " count)}]))
 
 (defn main []
-  (fn [points]
+  (fn [points scale-type]
     (let [only-one-column? (= (count (distinct points)) 1)
           unique-results (reduce (fn [new-set point] (conj new-set (:count point))) #{} points)
           only-one-count-result? (= (count unique-results) 1)
           show-graph? (not (or only-one-column? only-one-count-result?))
-          height-scale (linear-scale (apply max (map :count points)) 50)]
+          height-scale (scale scale-type (apply max (map :count points)) 50)]
       (if show-graph?
         (into [:div.graph.histogram]
               (map-indexed (fn [idx d]

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -394,7 +394,7 @@
         human-name (display-name model view)]
     [:h4.title
      (cond
-       numerical? (str "Showing numerical distribution for " (pretty-number (count results)) " " human-name)
+       numerical? (str "Showing numerical distribution for " (pretty-number uniqueValues) " " human-name)
        :else (if (< (count results) uniqueValues)
                (str "Showing " (pretty-number (count results)) " of "
                     (pretty-number uniqueValues) " " human-name)

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -70,8 +70,9 @@
                  :no-value? true}])
 
 (defn filter-input []
-  (fn [loc view val]
-    [:div.inline-filter [:i.fa.fa-filter]
+  (fn [loc view val !scale-type]
+    [:div.inline-filter
+     [:i.fa.fa-filter]
      [:input.form-control
       {:type "text"
        :value val
@@ -80,7 +81,12 @@
                     (dispatch [:select/set-text-filter
                                loc
                                view
-                               (oget e :target :value)]))}]]))
+                               (oget e :target :value)]))}]
+     [:button.btn.btn-default.btn-sm
+      {:type "button"
+       :on-click #(reset! !scale-type
+                          (if (= @!scale-type :linear) :log :linear))}
+      (name @!scale-type)]]))
 
 (defn force-close
   "Force a dropdown to close "
@@ -468,7 +474,8 @@
 (defn column-summary [loc view local-state !dropdown]
   (let [response (subscribe [:selection/response loc view])
         selections (subscribe [:selection/selections loc view])
-        text-filter (subscribe [:selection/text-filter loc view])]
+        text-filter (subscribe [:selection/text-filter loc view])
+        !scale-type (reagent/atom :linear)]
     (fn [loc view local-state !dropdown]
       (cond
         (nil? @response)
@@ -484,8 +491,8 @@
         [:form.form.column-summary
          [column-summary-title loc view @response]
          [:div.main-view
-          [histogram/main (:results @response)]
-          [filter-input loc view @text-filter]
+          [histogram/main (:results @response) @!scale-type]
+          [filter-input loc view @text-filter !scale-type]
           [:table.table.table-striped.table-condensed.table-scrollable
            [:thead [:tr [:th
                          (if (empty? @selections)


### PR DESCRIPTION
It seems the histogram in the numeric column summary was only partially implemented. While https://github.com/intermine/im-tables-3/pull/79/commits/f00951aee5de162742de670b793b0648a8f8c801 got it somewhat functional, this PR completes it, adds features present in the im-tables histogram, as well as new features that have been suggested:
- Linear/log scale toggle buttons
- Min and max labels for X axis
- Average line (with tooltip showing average)
- Tooltips for buckets showing interval and count of values

Linear/log scale toggle has also been added to the standard non-numeric column summary.