### PR TITLE
Fix styling problems when used in Bluegenes

### DIFF
--- a/less/modal.less
+++ b/less/modal.less
@@ -69,6 +69,9 @@
     .filter-item {
         display: flex;
         flex-flow: column;
+        // Bluegenes' CSS sets this to hidden, causing selector and calendar
+        // component to not be visible.
+        overflow: visible;
 
         .filter-name {
             margin-bottom: 0.5em;

--- a/less/site.less
+++ b/less/site.less
@@ -700,6 +700,10 @@
                 margin-right: @spacer/8;
             }
         }
+
+        .histo-scale {
+            display: flex;
+        }
     }
 
     .numerical-content-wrapper {
@@ -749,11 +753,16 @@
 
     .table-error {
         .button-group {
+            display: flex;
             margin-top: @spacer;
             margin-bottom: @spacer;
 
             button {
                 margin-right: @spacer/2;
+            }
+
+            .pull-right {
+                margin-left: auto;
             }
         }
     }

--- a/less/site.less
+++ b/less/site.less
@@ -54,6 +54,7 @@
     @histogram-bg: aliceblue;
     min-height: 200px;
     padding-bottom: 40px;
+    position: relative;
 
     .hljs {
         white-space: pre;

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -46,7 +46,9 @@
    :body [:div.modal-body
           [:form [:label "Select a format" [modal-body loc]]]
           [:a {:id "hiddendownloadlink" :download "download"}]]
-   :footer [:button.btn.btn-primary {:on-click (fn [] (dispatch [:exporttable/download loc]))} "Download now!"]})
+   :footer [:button.btn.btn-raised.btn-primary
+            {:on-click (fn [] (dispatch [:exporttable/download loc]))}
+            "Download now!"]})
 
 (defn exporttable [loc]
   [:button.btn.btn-default

--- a/src/im_tables/views/dashboard/manager/codegen/main.cljs
+++ b/src/im_tables/views/dashboard/manager/codegen/main.cljs
@@ -90,7 +90,7 @@
        [:button.btn.btn-default
         {:on-click #(dispatch [:modal/close loc])}
         "Close"]
-       [:button.btn.btn-primary
+       [:button.btn.btn-raised.btn-primary
         {:on-click (fn [] (save-to-disk "query" @code (:lang @options)))}
         [:i.fa.fa-save] " Download"]])))
 

--- a/src/im_tables/views/dashboard/manager/columns/main.cljs
+++ b/src/im_tables/views/dashboard/manager/columns/main.cljs
@@ -72,7 +72,7 @@
              [:button.btn.btn-default
               {:data-dismiss "modal"}
               "Cancel"]
-             [:button.btn.btn-success
+             [:button.btn.btn-raised.btn-success
               {:data-dismiss "modal"
                :disabled (< (count @selected) 1)
                :on-click (fn [] (dispatch [:tree-view/merge-new-columns loc]))}
@@ -95,7 +95,7 @@
        [:button.btn.btn-default
         {:on-click #(dispatch [:modal/close loc])}
         "Cancel"]
-       [:button.btn.btn-success
+       [:button.btn.btn-raised.btn-success
         {:data-dismiss "modal"
          :disabled (< (count @selected) 1)
          :on-click (fn []

--- a/src/im_tables/views/dashboard/manager/filters/main.cljs
+++ b/src/im_tables/views/dashboard/manager/filters/main.cljs
@@ -38,7 +38,7 @@
               (for [path (:select @query)]
                 [:option {:value path}
                  (str/join " » " (path/display-name @model path))]))
-        [:button.btn.btn-info.constraint-add
+        [:button.btn.btn-raised.btn-info.constraint-add
          {:on-click #(when-let [path @!path]
                        (dispatch [:main/fetch-possible-values loc path])
                        (dispatch [:filters/add-constraint loc {:path path
@@ -76,7 +76,7 @@
    [:button.btn.btn-default
     {:on-click #(dispatch [:modal/close loc])}
     "Cancel"]
-   [:button.btn.btn-success
+   [:button.btn.btn-raised.btn-success
     {:on-click (fn []
                  ; Apply the changes
                  (dispatch [:filters/save-changes loc])

--- a/src/im_tables/views/dashboard/manager/relationships/main.cljs
+++ b/src/im_tables/views/dashboard/manager/relationships/main.cljs
@@ -26,8 +26,9 @@
          [:div
           (into [:span] (join-with-arrows (path/display-name model view)))
           [:div.btn-group.pull-right
-           [:button.btn {:class (if (not is-join?) "btn-primary" "btn-default")
-                         :on-click rmv-join-fn}
+           [:button.btn.btn-raised
+            {:class (if (not is-join?) "btn-primary" "btn-default")
+             :on-click rmv-join-fn}
             ; You may ask why there are so many invisible icons here - it's (unfortunately)
             ; a hack to keep things visually aligned when switching from selected to unselected.
             ; We need the checkmarks to indicate clearly which is selected!
@@ -36,8 +37,9 @@
             [:i {:class (if (not is-join?) "fa fa-check" "fa fa-check invisible") :aria-hidden true}]
             " Required"
             [:i {:class "fa fa-check invisible fa-fw" :aria-hidden true}]]
-           [:button.btn {:class (if is-join? "btn-primary" "btn-default")
-                         :on-click add-join-fn}
+           [:button.btn.btn-raised
+            {:class (if is-join? "btn-primary" "btn-default")
+             :on-click add-join-fn}
             [:i {:class (if is-join? "fa fa-check" "fa fa-check invisible") :aria-hidden true}]
             " Optional"
             [:i {:class "fa fa-check invisible fa-fw" :aria-hidden true}]]]]
@@ -69,7 +71,7 @@
        [:button.btn.btn-default
         {:on-click #(dispatch [:modal/close loc])}
         "Cancel"]
-       [:button.btn.btn-success
+       [:button.btn.btn-raised.btn-success
         {:on-click (fn []
                      ; Apply the changes
                      (dispatch [:rel-manager/apply-changes loc])

--- a/src/im_tables/views/dashboard/save.cljs
+++ b/src/im_tables/views/dashboard/save.cljs
@@ -32,7 +32,7 @@
      [:button.btn.btn-default
       {:on-click #(dispatch [:modal/close loc])}
       "Cancel"]
-     [:button.btn.btn-success
+     [:button.btn.btn-raised.btn-success
       {:on-click on-submit}
       "Save"]]))
 

--- a/src/im_tables/views/table/error.cljs
+++ b/src/im_tables/views/table/error.cljs
@@ -75,11 +75,11 @@ ERROR: " query-error)))))
         :on-click toggle-error
         :class (when show-error? "active")}
        [:i.fa.fa-bug] " Show error"])
-    [:button.btn.btn-info
+    [:button.btn.btn-raised.btn-info
      {:type "button"
       :on-click #(dispatch [:im-tables/restart loc])}
      [:i.fa.fa-refresh] " Reset"]
-    [:a.btn.btn-primary.pull-right
+    [:a.btn.btn-raised.btn-primary.pull-right
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]
    (when show-query?
@@ -114,11 +114,11 @@ ERROR: " query-error)))))
         :on-click toggle-error
         :class (when show-error? "active")}
        [:i.fa.fa-code] " Show error"])
-    [:button.btn.btn-info
+    [:button.btn.btn-raised.btn-info
      {:type "button"
       :on-click #(dispatch [:main/retry-failure loc])}
      [:i.fa.fa-refresh] " Retry"]
-    [:a.btn.btn-primary.pull-right
+    [:a.btn.btn-raised.btn-primary.pull-right
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]
    (when show-query?
@@ -145,11 +145,11 @@ ERROR: " query-error)))))
         :on-click toggle-error
         :class (when show-error? "active")}
        [:i.fa.fa-code] " Show error"])
-    [:button.btn.btn-info
+    [:button.btn.btn-raised.btn-info
      {:type "button"
       :on-click clear-error!}
      [:i.fa.fa-refresh] " Reset"]
-    [:a.btn.btn-primary.pull-right
+    [:a.btn.btn-raised.btn-primary.pull-right
      {:href mailto}
      [:i.fa.fa-envelope] " Send a bug report"]]
    (when show-error?

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -337,7 +337,7 @@
            :possible-values @possible-values
            :disabled false
            :op op]]
-         [:button.btn.btn-danger.constraint-delete
+         [:button.btn.btn-raised.btn-danger.constraint-delete
           {:on-click (fn [] (dispatch [:filters/remove-constraint loc const]))
            :type "button"} [:i.fa.fa-times]]]))))
 

--- a/src/im_tables/views/table/head/controls.cljs
+++ b/src/im_tables/views/table/head/controls.cljs
@@ -11,7 +11,8 @@
             [im-tables.utils :refer [on-event pretty-number display-name]]
             [cljs-time.coerce :as time-coerce]
             [cljs-time.format :as time-format]
-            [goog.style :as gstyle]))
+            [goog.style :as gstyle]
+            [goog.dom :as gdom]))
 
 (def css-transition-group
   (reagent/adapt-react-class js/ReactTransitionGroup.CSSTransitionGroup))
@@ -547,7 +548,7 @@
                               (oget (gstyle/getSize below) :width))
                             above-w))
                    0)
-        pos (-> (gstyle/getClientPosition above)
+        pos (-> (gstyle/getRelativePosition above (gdom/getAncestorByClass above "im-table"))
                 (ocall :translate offset-x offset-y))]
     (gstyle/setPosition below pos)))
 


### PR DESCRIPTION
I didn't test my previous PRs #82 and #79 in Bluegenes, with its differing CSS, leading to bugs and styling issues. This PR fixes these:
- Buttons with unreadable text (actually a longstanding problem)
- Buttons appearing below instead of aside
- Calendar and selector not appearing in filter manager
- Positioning of filter panel and column summaries (these were way off due to being calculated relative to viewport, while being positioned relative to a parent element in Bluegenes instead of the viewport)