### PR TITLE
Support exporting with compression and Frictionless

### DIFF
--- a/less/modal.less
+++ b/less/modal.less
@@ -73,6 +73,25 @@
     }
 }
 
+.exporttable-body {
+    .export-options {
+        margin-top: 2em;
+    }
+
+    .panel {
+        margin-bottom: 0;
+
+        .panel-heading {
+            cursor: pointer;
+        }
+
+        .panel-heading.active {
+            color: white;
+            background-color: #337ab7;
+        }
+    }
+}
+
 .filter-manager {
     .filter-item {
         display: flex;

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -75,7 +75,9 @@
               :data-out {:selected-format :tsv
                          :accepted-formats {:tsv :all
                                             :csv :all
-                                            :fasta [:Gene :Protein]}}
+                                            :fasta [:Gene :Protein]}
+                         :export-data-package false
+                         :compression nil}
               :links {:vocab {:mine "flymine"}
                       :on-click nil
                       :url (fn [vocab] (str "#/reportpage/"

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -14,3 +14,15 @@
  (sandbox)
  (fn [db [_ loc format]]
    (assoc-in db [:settings :data-out :selected-format] (keyword format))))
+
+(reg-event-db
+ :exporttable/toggle-export-data-package
+ (sandbox)
+ (fn [db [_ loc]]
+   (update-in db [:settings :data-out :export-data-package] not)))
+
+(reg-event-db
+ :exporttable/set-compression
+ (sandbox)
+ (fn [db [_ loc compression-type]]
+   (assoc-in db [:settings :data-out :compression] compression-type)))

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -8,96 +8,9 @@
 ;; REMEMBER KIDS, some gene identifiers have a comma in them, because insanity.
 ;; This means we default to tsv for Good Reasons. (This is set in the app-db!)
 
-(defn encode-file
-  "Encode a stringified text file such that it can be downloaded by the browser.
-  Results must be stringified - don't pass objects / vectors / arrays / whatever."
-  [data filetype]
-  (ocall js/URL "createObjectURL" (js/Blob. (clj->js [data]) {:type (str "text/" filetype)})))
-
-(defn stringify-query-results
-  "converts results into a csv/tsv-style string."
-  [file-type query-results]
-  (let [separator (:separator file-type)
-        vec-file
-        (reduce (fn [new-str [i rowvals]]
-                  (conj new-str
-                        (join separator (reduce (fn [new-sub-str rowval]
-                                                  (conj new-sub-str (:value rowval))) [] rowvals)))) [] query-results)]
-    (join "\n" vec-file)))
-
-;;config for various file types
-;;probably should be abstracted to somewhere else more central
-(def xsv {:csv {:file-type "csv" :separator ","}
-          :tsv {:file-type "tsv" :separator "\t"}
-          :fasta {:file-type "fasta"}})
-
 (reg-event-db
  :exporttable/set-format
  ;;sets preferred format for the file export
  (sandbox)
  (fn [db [_ loc format]]
    (assoc-in db [:settings :data-out :selected-format] (keyword format))))
-
-(reg-event-fx
- :exporttable/download
- ;;the main action to download files. This gets called by the download modal button.
- (sandbox)
- (fn [{db :db} [_ loc]]
-   (let [query-results (get-in db [:response :results])
-         file-type ((get-in db [:settings :data-out :selected-format]) xsv)
-         query (get-in db [:query])]
-     (if (= (:file-type file-type) "fasta")
-       ;;fasta queries need to have only one column selected, so have slightly
-       ;; differetnt conditions
-       {:db db :dispatch [:exporttable/run-fasta-query loc file-type]}
-       {:db db :dispatch [:exporttable/run-export-query loc file-type]}))))
-
-(defn set-download-link-properties
-  "We're setting the attributes of a link with the download property enabled,
-   then clicking it programatically.
-   This spawns a nice download without having to create a new window
-   which might be pop-up blocked. It also allows us to set the filename.
-   We live in the future!"
-  [results file-type]
-  (let [downloadlink (ocall js/document :getElementById "hiddendownloadlink")]
-    (ocall downloadlink :setAttribute "href" (encode-file results file-type))
-    (ocall downloadlink :setAttribute "download" (str "results." file-type))
-    (ocall downloadlink :click)))
-
-(reg-event-fx
- :exporttable/download-export-response
- ;;fx event handler for downloading the file once the query is complete
- (sandbox)
- (fn [{db :db} [_ loc file-type results]]
-   (set-download-link-properties results (:file-type file-type))
-   {:db db}))
-
-(reg-event-fx
- :exporttable/run-export-query
- ;; default query dispatch to download *all* the rows for this query
- ;; we can't use the data we have because it's limited to the first page or two
- ;; around 40 records. Many queries are bigger than this.
- (sandbox)
- (fn [{db :db} [_ loc file-type]]
-   {:im-tables/im-operation
-    {:on-success [:exporttable/download-export-response loc file-type]
-     :op         (partial fetch/fetch-custom-format
-                          (get db :service)
-                          (get db :query)
-                          {:format (:file-type file-type)})}
-    :db db}))
-
-(reg-event-fx
- :exporttable/run-fasta-query
- ;;like run-export-query but limited to selecting one column as required by
- ;;the fasta endpoint
- (sandbox)
- (fn [{db :db} [_ loc file-type]]
-   (let [query (get db :query)
-         fasta-query (assoc query :select ["id"])]
-     {:im-tables/im-operation
-      {:on-success [:exporttable/download-export-response loc file-type]
-       :op         (partial fetch/fasta
-                            (get db :service)
-                            fasta-query)}
-      :db db})))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -341,7 +341,7 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [selected-format]} {:keys [root token]} query model]
+ (fn [[{:keys [selected-format export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [fasta? (= selected-format :fasta)]
      (str root "/service/query/results" (when fasta? "/fasta")
@@ -350,7 +350,8 @@
           "&query=" (js/encodeURIComponent
                       (im-query/->xml model (cond-> query
                                               fasta? (assoc :select ["id"]))))
+          (if export-data-package
+            "&exportDataPackage=true&compress=zip"
+            (when compression
+              (str "&compress=" (name compression))))
           "&token=" token))))
-          ;; TODO add options for these
-          ; "&exportDataPackage=" true
-          ; "&compress=" "zip"))))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -348,8 +348,8 @@
           "?format=" (name selected-format)
           "&filename=" "results"
           "&query=" (js/encodeURIComponent
-                      (im-query/->xml model (cond-> query
-                                              fasta? (assoc :select ["id"]))))
+                     (im-query/->xml model (cond-> query
+                                             fasta? (assoc :select ["id"]))))
           (if export-data-package
             "&exportDataPackage=true&compress=zip"
             (when compression

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -333,3 +333,24 @@
  :pick-items/class
  (fn [db [_ loc]]
    (get-in db (glue loc [:pick-items :class]))))
+
+(reg-sub
+ :export/download-href
+ (fn [[_ loc]]
+   [(subscribe [:settings/data-out loc])
+    (subscribe [:assets/service loc])
+    (subscribe [:main/query loc])
+    (subscribe [:assets/model loc])])
+ (fn [[{:keys [selected-format]} {:keys [root token]} query model]
+      [_ _loc]]
+   (let [fasta? (= selected-format :fasta)]
+     (str root "/service/query/results" (when fasta? "/fasta")
+          "?format=" (name selected-format)
+          "&filename=" "results"
+          "&query=" (js/encodeURIComponent
+                      (im-query/->xml model (cond-> query
+                                              fasta? (assoc :select ["id"]))))
+          "&token=" token))))
+          ;; TODO add options for these
+          ; "&exportDataPackage=" true
+          ; "&compress=" "zip"))))

--- a/src/im_tables/views.cljs
+++ b/src/im_tables/views.cljs
@@ -143,15 +143,15 @@
                       :url (fn [{:keys [mine class objectId] :as _vocab}]
                              (string/join "/" [nil mine "report" class objectId]))}}})
 
-(def pagination-bug
+(def humanmine-config-2
   {:service {:root "https://www.humanmine.org/humanmine"}
    :query {:from "Gene"
-           :select ["Gene.overlappingFeatures.primaryIdentifier",
-                    "Gene.overlappingFeatures.length",
-                    "Gene.overlappingFeatures.organism.name"]
-           :where [{:path "Gene.id"
-                    :op "="
-                    :value "1016209"}]}
+           :select ["Gene.symbol"
+                    "Gene.primaryIdentifier"
+                    "Gene.organism.name"]
+           :where [{:path "Gene.symbol"
+                    :op "LIKE"
+                    :value "*g"}]}
    :settings {:pagination {:limit 10}
               :links {:vocab {:mine "humanmine"}
                       :url (fn [{:keys [mine class objectId] :as _vocab}]
@@ -168,7 +168,7 @@
 (def number-of-tables 1)
 (defn reboot-tables-fn []
   (dotimes [n number-of-tables]
-    (re-frame/dispatch-sync [:im-tables/load [:test :location n] subclass-config])))
+    (re-frame/dispatch-sync [:im-tables/load [:test :location n] humanmine-config-2])))
 
 (defn main-panel []
   (let [show? (r/atom true)]


### PR DESCRIPTION
Adds an accordion component to the export modal which provides the users options for exporting as a Frictionless Data Package or with zip or gzip compression.

Copies the functionality and text from https://github.com/intermine/im-tables/pull/237

Note that this includes a change in how exporting is done in im-tables-3. Previously a blob would be created and assigned to a hidden anchor element's href attribute, with its download attribute set to the filename, which would then be programmatically clicked. I couldn't get this to save valid compressed archives, so I reverted to im-tables' approach of using a download button with its href attribute set to a GET request (using the mine's server URL followed by web service and query parameters), which when clicked causes the browser to download the file due to the server's response including the `content-disposition: attachment; filename="results.csv.zip"` header. Not sure why the original im-tables' approach wasn't adopted initially.
