### PR TITLE
Expand export modal

### DIFF
--- a/less/modal.less
+++ b/less/modal.less
@@ -90,6 +90,10 @@
             background-color: #337ab7;
         }
     }
+
+    .format-dropdown {
+        width: auto;
+    }
 }
 
 .filter-manager {
@@ -150,7 +154,7 @@
     }
 }
 
-.save-body {
+.modal-body {
     .optional-attributes {
         margin-top: 2.5em;
         position: relative;
@@ -163,6 +167,10 @@
             transform: translate(-50%, -50%);
             background-color: white;
             padding: 0 1em;
+        }
+
+        label {
+            font-weight: normal;
         }
     }
 }

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -87,6 +87,7 @@
                          :columnheaders nil
                          :size nil
                          :start 0
+                         :select nil
                          :export-data-package false
                          :compression nil}
               :links {:vocab {:mine "flymine"}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -72,13 +72,15 @@
                         :comments? true
                         :html? true
                         :highlight? true}
-              :data-out {:selected-format :tsv
+              :data-out {:filename "results"
+                         :selected-format :tsv
                          :accepted-formats {:tsv :all
                                             :csv :all
                                             :fasta [:Gene :Protein]
                                             :rdf :all
                                             :ntriples :all}
                          :order-formats [:tsv :csv :fasta :rdf :ntriples]
+                         :column-headers nil
                          :export-data-package false
                          :compression nil}
               :links {:vocab {:mine "flymine"}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -88,6 +88,7 @@
                          :size nil
                          :start 0
                          :select nil
+                         :remove #{}
                          :export-data-package false
                          :compression nil}
               :links {:vocab {:mine "flymine"}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -76,10 +76,14 @@
                          :format "tsv"
                          :accepted-formats {:tsv :all
                                             :csv :all
+                                            :xml :all
+                                            :json :all
                                             :fasta [:Gene :Protein]
+                                            :gff3 [:Gene :Protein]
+                                            :bed [:Gene :Protein]
                                             :rdf :all
                                             :ntriples :all}
-                         :order-formats [:tsv :csv :fasta :rdf :ntriples]
+                         :order-formats [:tsv :csv :xml :json :fasta :gff3 :bed :rdf :ntriples]
                          :columnheaders nil
                          :export-data-package false
                          :compression nil}

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -73,14 +73,14 @@
                         :html? true
                         :highlight? true}
               :data-out {:filename "results"
-                         :selected-format :tsv
+                         :format "tsv"
                          :accepted-formats {:tsv :all
                                             :csv :all
                                             :fasta [:Gene :Protein]
                                             :rdf :all
                                             :ntriples :all}
                          :order-formats [:tsv :csv :fasta :rdf :ntriples]
-                         :column-headers nil
+                         :columnheaders nil
                          :export-data-package false
                          :compression nil}
               :links {:vocab {:mine "flymine"}
@@ -98,4 +98,5 @@
            :summary {}
            :selection {}
            :filters {}
-           :tree-view {:selection #{}}}})
+           :tree-view {:selection #{}}
+           :export-preview nil}})

--- a/src/im_tables/db.cljs
+++ b/src/im_tables/db.cljs
@@ -85,6 +85,8 @@
                                             :ntriples :all}
                          :order-formats [:tsv :csv :xml :json :fasta :gff3 :bed :rdf :ntriples]
                          :columnheaders nil
+                         :size nil
+                         :start 0
                          :export-data-package false
                          :compression nil}
               :links {:vocab {:mine "flymine"}

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -1,12 +1,30 @@
 (ns im-tables.events.exporttable
   (:require [re-frame.core :refer [reg-event-db reg-event-fx reg-fx]]
             [oops.core :refer [oget ocall ocall! ocall+]]
-            [clojure.string :refer [join]]
+            [clojure.string :refer [join replace]]
             [imcljs.fetch :as fetch]
             [im-tables.interceptors :refer [sandbox]]))
 
 ;; REMEMBER KIDS, some gene identifiers have a comma in them, because insanity.
 ;; This means we default to tsv for Good Reasons. (This is set in the app-db!)
+
+(reg-event-db
+ :exporttable/prepare-options
+ (sandbox)
+ (fn [db [_ loc]]
+   (assoc-in db [:settings :data-out :filename]
+             (str (when-let [mine-ns (not-empty (get-in db [:settings :links :vocab :mine]))]
+                    (str mine-ns "_"))
+                  "results_"
+                  ;; This creates a filename friendly date and time string.
+                  (let [date (js/Date.)]
+                    ;; Adjust for the timezone and daylight saving components, so we can convert to ISO format without displaying zero UTC time.
+                    (.setMinutes date (- (.getMinutes date) (.getTimezoneOffset date)))
+                    (-> (.toISOString date)
+                        ;; Remove the millisecond counter and Z suffix, as we removed the UTC offset above.
+                        (replace #"\..*$" "")
+                        ;; Remove the : character as it's not supported in most filesystems.
+                        (replace #":" "")))))))
 
 (reg-event-fx
  :exporttable/fetch-preview

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -12,29 +12,33 @@
  :exporttable/prepare-options
  (sandbox)
  (fn [db [_ loc]]
-   (assoc-in db [:settings :data-out :filename]
-             (str (when-let [mine-ns (not-empty (get-in db [:settings :links :vocab :mine]))]
-                    (str mine-ns "_"))
-                  "results_"
-                  ;; This creates a filename friendly date and time string.
-                  (let [date (js/Date.)]
-                    ;; Adjust for the timezone and daylight saving components, so we can convert to ISO format without displaying zero UTC time.
-                    (.setMinutes date (- (.getMinutes date) (.getTimezoneOffset date)))
-                    (-> (.toISOString date)
-                        ;; Remove the millisecond counter and Z suffix, as we removed the UTC offset above.
-                        (replace #"\..*$" "")
-                        ;; Remove the : character as it's not supported in most filesystems.
-                        (replace #":" "")))))))
+   (update-in db [:settings :data-out] assoc
+
+              :size (get-in db [:response :iTotalRecords])
+              :start 0
+
+              :filename
+              (str (when-let [mine-ns (not-empty (get-in db [:settings :links :vocab :mine]))]
+                     (str mine-ns "_"))
+                   "results_"
+                   ;; This creates a filename friendly date and time string.
+                   (let [date (js/Date.)]
+                     ;; Adjust for the timezone and daylight saving components, so we can convert to ISO format without displaying zero UTC time.
+                     (.setMinutes date (- (.getMinutes date) (.getTimezoneOffset date)))
+                     (-> (.toISOString date)
+                         ;; Remove the millisecond counter and Z suffix, as we removed the UTC offset above.
+                         (replace #"\..*$" "")
+                         ;; Replace the : character as it's not supported in most filesystems.
+                         (replace #":" "-")))))))
 
 (reg-event-fx
  :exporttable/fetch-preview
  (sandbox)
  (fn [{db :db} [_ loc]]
-   (let [options (merge
-                   (select-keys (get-in db [:settings :data-out])
-                                [:format :columnheaders])
-                   {:start 0
-                    :size 3})]
+   (let [data-out (get-in db [:settings :data-out])
+         options (merge
+                   (select-keys data-out [:format :columnheaders :start])
+                   {:size 3})]
      (if (contains? #{"fasta" "gff3" "bed"} (:format options))
        {:db (assoc-in db [:cache :export-preview] "Previews are not supported for bioinformatics formats")}
        {:db (assoc-in db [:cache :export-preview] nil)
@@ -75,6 +79,18 @@
  (fn [{db :db} [_ loc colum-headers-type]]
    {:db (assoc-in db [:settings :data-out :columnheaders] colum-headers-type)
     :dispatch [:exporttable/fetch-preview loc]}))
+
+(reg-event-fx
+ :exporttable/set-rows-size
+ (sandbox)
+ (fn [{db :db} [_ loc size]]
+   {:db (assoc-in db [:settings :data-out :size] size)}))
+
+(reg-event-fx
+ :exporttable/set-rows-start
+ (sandbox)
+ (fn [{db :db} [_ loc offset]]
+   {:db (assoc-in db [:settings :data-out :start] offset)}))
 
 (reg-event-db
  :exporttable/toggle-export-data-package

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -9,6 +9,12 @@
 ;; This means we default to tsv for Good Reasons. (This is set in the app-db!)
 
 (reg-event-db
+ :exporttable/set-filename
+ (sandbox)
+ (fn [db [_ loc filename]]
+   (assoc-in db [:settings :data-out :filename] filename)))
+
+(reg-event-db
  :exporttable/set-format
  ;;sets preferred format for the file export
  (sandbox)

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -26,3 +26,9 @@
  (sandbox)
  (fn [db [_ loc compression-type]]
    (assoc-in db [:settings :data-out :compression] compression-type)))
+
+(reg-event-db
+ :exporttable/set-column-headers
+ (sandbox)
+ (fn [db [_ loc colum-headers-type]]
+   (assoc-in db [:settings :data-out :column-headers] colum-headers-type)))

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -40,8 +40,8 @@
  (fn [{db :db} [_ loc]]
    (let [data-out (get-in db [:settings :data-out])
          options (merge
-                   (select-keys data-out [:format :columnheaders :start])
-                   {:size 3})
+                  (select-keys data-out [:format :columnheaders :start])
+                  {:size 3})
          query (cond-> (:query db)
                  (:select data-out) (assoc :select (vec (keep #(when-not (contains? (:remove data-out) %) %)
                                                               (:select data-out)))))]

--- a/src/im_tables/events/exporttable.cljs
+++ b/src/im_tables/events/exporttable.cljs
@@ -32,7 +32,8 @@
  :exporttable/fetch-preview-failure
  (sandbox)
  (fn [db [_ loc res]]
-   (assoc-in db [:cache :export-preview] res)))
+   (assoc-in db [:cache :export-preview] (or (not-empty (:body res))
+                                             "Failed to fetch preview"))))
 
 (reg-event-db
  :exporttable/set-filename

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -378,7 +378,7 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [filename format columnheaders size start select export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [filename format columnheaders size start select remove export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [sequence? (contains? #{"fasta" "gff3" "bed"} format)]
      (str root "/service/query/results" (when sequence? (str "/" format))
@@ -387,7 +387,7 @@
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond
                                              sequence? (assoc query :select ["id"])
-                                             select (assoc query :select select)
+                                             select (assoc query :select (vec (keep #(when-not (contains? remove %) %) select)))
                                              :else query)))
           (when size (str "&size=" size))
           (when start (str "&start=" start))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -380,13 +380,13 @@
     (subscribe [:assets/model loc])])
  (fn [[{:keys [filename format columnheaders export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
-   (let [fasta? (= format "fasta")]
-     (str root "/service/query/results" (when fasta? "/fasta")
+   (let [sequence? (contains? #{"fasta" "gff3" "bed"} format)]
+     (str root "/service/query/results" (when sequence? (str "/" format))
           "?format=" format
           "&filename=" (or filename "results")
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond-> query
-                                             fasta? (assoc :select ["id"]))))
+                                             sequence? (assoc :select ["id"]))))
           (when columnheaders
             (str "&columnheaders=" columnheaders))
           (if export-data-package

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -373,12 +373,12 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [selected-format column-headers export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [filename selected-format column-headers export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [fasta? (= selected-format :fasta)]
      (str root "/service/query/results" (when fasta? "/fasta")
           "?format=" (name selected-format)
-          "&filename=" "results"
+          "&filename=" (or filename "results")
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond-> query
                                              fasta? (assoc :select ["id"]))))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -133,6 +133,11 @@
    (get-in db (glue prefix [:cache :tree-view :selection]))))
 
 (reg-sub
+ :exporttable/preview
+ (fn [db [_ prefix]]
+   (get-in db (glue prefix [:cache :export-preview]))))
+
+(reg-sub
  :modal
  (fn [db [_ prefix]]
    (get-in db (glue prefix [:cache :modal]))))
@@ -373,19 +378,19 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [filename selected-format column-headers export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [filename format columnheaders export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
-   (let [fasta? (= selected-format :fasta)]
+   (let [fasta? (= format "fasta")]
      (str root "/service/query/results" (when fasta? "/fasta")
-          "?format=" (name selected-format)
+          "?format=" format
           "&filename=" (or filename "results")
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond-> query
                                              fasta? (assoc :select ["id"]))))
-          (when column-headers
-            (str "&columnheaders=" (name column-headers)))
+          (when columnheaders
+            (str "&columnheaders=" columnheaders))
           (if export-data-package
             "&exportDataPackage=true&compress=zip"
             (when compression
-              (str "&compress=" (name compression))))
+              (str "&compress=" compression)))
           "&token=" token))))

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -378,7 +378,7 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [filename format columnheaders export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [filename format columnheaders size start export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [sequence? (contains? #{"fasta" "gff3" "bed"} format)]
      (str root "/service/query/results" (when sequence? (str "/" format))
@@ -387,6 +387,8 @@
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond-> query
                                              sequence? (assoc :select ["id"]))))
+          (when size (str "&size=" size))
+          (when start (str "&start=" start))
           (when columnheaders
             (str "&columnheaders=" columnheaders))
           (if export-data-package

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -373,7 +373,7 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [selected-format export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [selected-format column-headers export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [fasta? (= selected-format :fasta)]
      (str root "/service/query/results" (when fasta? "/fasta")
@@ -382,6 +382,8 @@
           "&query=" (js/encodeURIComponent
                      (im-query/->xml model (cond-> query
                                              fasta? (assoc :select ["id"]))))
+          (when column-headers
+            (str "&columnheaders=" (name column-headers)))
           (if export-data-package
             "&exportDataPackage=true&compress=zip"
             (when compression

--- a/src/im_tables/subs.cljs
+++ b/src/im_tables/subs.cljs
@@ -378,15 +378,17 @@
     (subscribe [:assets/service loc])
     (subscribe [:main/query loc])
     (subscribe [:assets/model loc])])
- (fn [[{:keys [filename format columnheaders size start export-data-package compression]} {:keys [root token]} query model]
+ (fn [[{:keys [filename format columnheaders size start select export-data-package compression]} {:keys [root token]} query model]
       [_ _loc]]
    (let [sequence? (contains? #{"fasta" "gff3" "bed"} format)]
      (str root "/service/query/results" (when sequence? (str "/" format))
           "?format=" format
           "&filename=" (or filename "results")
           "&query=" (js/encodeURIComponent
-                     (im-query/->xml model (cond-> query
-                                             sequence? (assoc :select ["id"]))))
+                     (im-query/->xml model (cond
+                                             sequence? (assoc query :select ["id"])
+                                             select (assoc query :select select)
+                                             :else query)))
           (when size (str "&size=" size))
           (when start (str "&start=" start))
           (when columnheaders

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -75,6 +75,31 @@
               :checked (= columnheaders "path")}]
      " Use raw path headers (e.g. " [:em "Gene.organism.name"] ")"]]])
 
+(defn rows-panel [loc {:keys [size start]}]
+  (let [{total :iTotalRecords} @(subscribe [:main/query-response loc])]
+    [optional-container "Select rows"
+     [:div
+      [:div.form-group
+       [:label (str "Size: " size) (when (= size total) " (all rows)")]
+       [:input
+        {:type "range"
+         :name "size"
+         :step 1
+         :min 1
+         :max total
+         :value size
+         :on-change #(dispatch [:exporttable/set-rows-size loc (js/parseInt (oget % :target :value))])}]]
+      [:div.form-group
+       [:label (str "Offset: " start)]
+       [:input
+        {:type "range"
+         :name "start"
+         :step 1
+         :min 0
+         :max (dec total)
+         :value start
+         :on-change #(dispatch [:exporttable/set-rows-start loc (js/parseInt (oget % :target :value))])}]]]]))
+
 (defn data-package-panel [loc {:keys [export-data-package]}]
   [optional-container "Frictionless Data Package"
    [:label
@@ -130,6 +155,7 @@
      [:div.export-options
       [preview-panel loc]
       [column-headers-panel loc data-out]
+      [rows-panel loc data-out]
       [data-package-panel loc data-out]
       [compression-panel loc data-out]]]))
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -6,6 +6,17 @@
             [imcljs.path :as path :refer [walk class]]
             [im-tables.components.bootstrap :refer [modal]]))
 
+(def format->styling
+  {:tsv [:span [:i.fa.fa-file-excel-o] " Tab separated values"]
+   :csv [:span [:i.fa.fa-file-excel-o] " Comma separated values"]
+   :xml [:span [:i.fa.fa-code] " XML"]
+   :json [:span "{ } JSON"]
+   :fasta [:span [:i.fa.fa-exchange] " FASTA sequence"]
+   :gff3 [:span [:i.fa.fa-exchange] " GFF3 features"]
+   :bed [:span [:i.fa.fa-exchange] " BED locations"]
+   :rdf [:span [:i.fa.fa-sitemap] " RDF"]
+   :ntriples [:span [:i.fa.fa-sitemap] " N-Triples"]})
+
 (defn format-dropdown
   "creates the dropdown to allow users to select their preferred format"
   [loc {:keys [format accepted-formats order-formats]}]
@@ -16,11 +27,16 @@
                                                     ;; If not :all, it's a vector of classes which the query needs to have.
                                                     (some #(contains? query-parts (name %)) suitable-for))
                                             format))))]
-    (into [:select.form-control.format-dropdown
-           {:value format
-            :on-change #(dispatch [:exporttable/set-format loc (oget % "target" "value")])}]
-          (for [format valid-export-formats]
-            [:option (name format)]))))
+    [:div.dropdown
+     [:button.btn.btn-default.btn-toolbar.dropdown-toggle
+      {:data-toggle "dropdown"}
+      format]
+     (into [:ul.dropdown-menu.dropdown-menu-right]
+           (for [format valid-export-formats]
+             [:li
+              [:button.btn.btn-link.btn-block
+               {:on-click #(dispatch [:exporttable/set-format loc (name format)])}
+               (get format->styling format (name format))]]))]))
 
 (defn optional-container [title & children]
   (into [:div.optional-attributes
@@ -50,7 +66,7 @@
               :name "colum-headers-type"
               :on-change #(dispatch [:exporttable/set-column-headers loc "friendly"])
               :checked (= columnheaders "friendly")}]
-     " Use human readable headers (e.g. " [:em "Gene > Organism . Name"] ")"]]
+     " Use human readable headers (e.g. " [:em "Gene > Organism Name"] ")"]]
    [:div.radio
     [:label
      [:input {:type "radio"
@@ -124,7 +140,7 @@
   (let [href @(subscribe [:export/download-href loc])]
     [:a.btn.btn-raised.btn-primary
      {:href href}
-     "Download now!"]))
+     "Download file"]))
 
 (defn export-menu
   "UI element. Presents the modal to allow user to select an export format."

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -31,7 +31,7 @@
                                                     (some #(contains? query-parts (name %)) suitable-for))
                                             format))))]
     [:div.dropdown
-     [:button.btn.btn-default.btn-toolbar.dropdown-toggle
+     [:button.btn.btn-default.btn-raised.btn-toolbar.dropdown-toggle
       {:data-toggle "dropdown"}
       format]
      (into [:ul.dropdown-menu.dropdown-menu-right]

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -8,7 +8,7 @@
 
 (defn format-dropdown
   "creates the dropdown to allow users to select their preferred format"
-  [loc {:keys [accepted-formats order-formats]}]
+  [loc {:keys [format accepted-formats order-formats]}]
   (let [query-parts @(subscribe [:main/query-parts loc])
         valid-export-formats (->> (map (juxt identity accepted-formats) order-formats)
                                   (keep (fn [[format suitable-for]]
@@ -17,7 +17,8 @@
                                                     (some #(contains? query-parts (name %)) suitable-for))
                                             format))))]
     (into [:select.form-control.format-dropdown
-           {:on-change #(dispatch [:exporttable/set-format loc (oget % "target" "value")])}]
+           {:value format
+            :on-change #(dispatch [:exporttable/set-format loc (oget % "target" "value")])}]
           (for [format valid-export-formats]
             [:option (name format)]))))
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -100,7 +100,9 @@
        [:label "File name and type"]
        [:div.input-group
         [:input.form-control
-         {:type "text"}]
+         {:type "text"
+          :value (:filename data-out)
+          :on-change #(dispatch [:exporttable/set-filename loc (oget % :target :value)])}]
         [:div.input-group-btn
          [format-dropdown loc]]]]]
      [:div.export-options

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -154,6 +154,7 @@
    {:type "button"
     :on-click (fn []
                 (dispatch [:exporttable/fetch-preview loc])
+                (dispatch [:exporttable/prepare-options loc])
                 (dispatch [:modal/open loc (export-menu loc)]))}
    [:i.fa.fa-download] " Export"])
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -103,6 +103,20 @@
          :value start
          :on-change #(dispatch [:exporttable/set-rows-start loc (js/parseInt (oget % :target :value))])}]]]]))
 
+(defn columns-panel [loc {:keys [select]}]
+  (let [model @(subscribe [:assets/model loc])
+        {views :select} @(subscribe [:main/query loc])
+        selected (set select)]
+    [optional-container "Select columns"
+     (into [:ul.list-group]
+           (for [[i view] (map-indexed vector views)]
+             [:li.list-group-item
+              [:label
+               [:input {:type "checkbox"
+                        :checked (contains? selected view)
+                        :on-change #(dispatch [:exporttable/toggle-select-view loc i view])}]
+               (str " " (path/friendly model view))]]))]))
+
 (defn data-package-panel [loc {:keys [export-data-package]}]
   [optional-container "Frictionless Data Package"
    [:label
@@ -161,6 +175,8 @@
         [column-headers-panel loc data-out])
       (when-not (bioinf? format)
         [rows-panel loc data-out])
+      (when-not (bioinf? format)
+        [columns-panel loc data-out])
       [data-package-panel loc data-out]
       [compression-panel loc data-out]]]))
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -23,10 +23,38 @@
           (for [format valid-export-formats]
             [:option (name format)]))))
 
+(defn optional-container [title & children]
+  (into [:div.optional-attributes
+         [:hr]
+         [:span title]]
+        children))
+
+(defn column-headers-panel [loc {:keys [column-headers]}]
+  [optional-container "Column headers"
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "colum-headers-type"
+              :on-change #(dispatch [:exporttable/set-column-headers loc nil])
+              :checked (nil? column-headers)}]
+     " No column headers"]]
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "colum-headers-type"
+              :on-change #(dispatch [:exporttable/set-column-headers loc :friendly])
+              :checked (= column-headers :friendly)}]
+     " Use human readable headers (e.g. " [:em "Gene > Organism . Name"] ")"]]
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "colum-headers-type"
+              :on-change #(dispatch [:exporttable/set-column-headers loc :path])
+              :checked (= column-headers :path)}]
+     " Use raw path headers (e.g. " [:em "Gene.organism.name"] ")"]]])
+
 (defn data-package-panel [loc {:keys [export-data-package]}]
-  [:div.optional-attributes
-   [:hr]
-   [:span "Frictionless Data Package"]
+  [optional-container "Frictionless Data Package"
    [:label
     [:input {:type "checkbox"
              :on-change #(dispatch [:exporttable/toggle-export-data-package loc])
@@ -34,32 +62,34 @@
     " Export Frictionless Data Package (uses ZIP compression)"]])
 
 (defn compression-panel [loc {:keys [export-data-package compression]}]
-  [:div.optional-attributes
-   [:hr]
-   [:span "Compression"]
+  [optional-container "Compression"
    (when export-data-package
-     [:p [:strong "Frictionless Data Package uses ZIP Compression only."]])
-   [:label
-    [:input {:type "radio"
-             :name "compression-type"
-             :disabled export-data-package
-             :on-change #(dispatch [:exporttable/set-compression loc nil])
-             :checked (nil? compression)}]
-    " No compression"]
-   [:label
-    [:input {:type "radio"
-             :name "compression-type"
-             :disabled export-data-package
-             :on-change #(dispatch [:exporttable/set-compression loc :zip])
-             :checked (= compression :zip)}]
-    " Use Zip compression (produces a .zip archive)"]
-   [:label
-    [:input {:type "radio"
-             :name "compression-type"
-             :disabled export-data-package
-             :on-change #(dispatch [:exporttable/set-compression loc :gzip])
-             :checked (= compression :gzip)}]
-    " Use GZIP compression (produces a .gzip archive)"]])
+     [:div.alert.alert-warning {:role "alert"}
+      [:p "Frictionless Data Package uses ZIP Compression only."]])
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "compression-type"
+              :disabled export-data-package
+              :on-change #(dispatch [:exporttable/set-compression loc nil])
+              :checked (nil? compression)}]
+     " No compression"]]
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "compression-type"
+              :disabled export-data-package
+              :on-change #(dispatch [:exporttable/set-compression loc :zip])
+              :checked (= compression :zip)}]
+     " Use Zip compression (produces a .zip archive)"]]
+   [:div.radio
+    [:label
+     [:input {:type "radio"
+              :name "compression-type"
+              :disabled export-data-package
+              :on-change #(dispatch [:exporttable/set-compression loc :gzip])
+              :checked (= compression :gzip)}]
+     " Use GZIP compression (produces a .gzip archive)"]]])
 
 (defn modal-body
   [loc]
@@ -67,13 +97,14 @@
     [:div.exporttable-body
      [:div.form
       [:div.form-group
-       [:label "File name"]
+       [:label "File name and type"]
        [:div.input-group
         [:input.form-control
          {:type "text"}]
         [:div.input-group-btn
          [format-dropdown loc]]]]]
      [:div.export-options
+      [column-headers-panel loc data-out]
       [data-package-panel loc data-out]
       [compression-panel loc data-out]]]))
 

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -30,7 +30,9 @@
 (defn preview-panel [loc]
   (let [preview @(subscribe [:exporttable/preview loc])]
     [optional-container "Preview (first 3 rows)"
-     [:pre preview]]))
+     (if (nil? preview)
+       [:pre [:code.nohighlight "Fetching preview... " [:i.fa.fa-fw.fa-spinner.fa-spin]]]
+       [:pre preview])]))
 
 (defn column-headers-panel [loc {:keys [columnheaders]}]
   [optional-container "Column headers"

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -103,19 +103,26 @@
          :value start
          :on-change #(dispatch [:exporttable/set-rows-start loc (js/parseInt (oget % :target :value))])}]]]]))
 
-(defn columns-panel [loc {:keys [select]}]
+(defn columns-panel [loc {:keys [select remove]}]
   (let [model @(subscribe [:assets/model loc])
-        {views :select} @(subscribe [:main/query loc])
-        selected (set select)]
+        select-count (count select)]
     [optional-container "Select columns"
      (into [:ul.list-group]
-           (for [[i view] (map-indexed vector views)]
+           (for [[i view] (map-indexed vector select)]
              [:li.list-group-item
               [:label
                [:input {:type "checkbox"
-                        :checked (contains? selected view)
-                        :on-change #(dispatch [:exporttable/toggle-select-view loc i view])}]
-               (str " " (path/friendly model view))]]))]))
+                        :checked (not (contains? remove view))
+                        :on-change #(dispatch [:exporttable/toggle-select-view loc view])}]
+               (str " " (path/friendly model view))]
+              [:button.btn.btn-default.btn-xs.pull-right
+               {:disabled (zero? i)
+                :on-click #(dispatch [:exporttable/move-view-up loc i])}
+               [:i.fa.fa-chevron-up]]
+              [:button.btn.btn-default.btn-xs.pull-right
+               {:disabled (= i (dec select-count))
+                :on-click #(dispatch [:exporttable/move-view-down loc i])}
+               [:i.fa.fa-chevron-down]]]))]))
 
 (defn data-package-panel [loc {:keys [export-data-package]}]
   [optional-container "Frictionless Data Package"

--- a/src/im_tables/views/dashboard/exporttable.cljs
+++ b/src/im_tables/views/dashboard/exporttable.cljs
@@ -17,6 +17,9 @@
    :rdf [:span [:i.fa.fa-sitemap] " RDF"]
    :ntriples [:span [:i.fa.fa-sitemap] " N-Triples"]})
 
+(defn bioinf? [format] (contains? #{"fasta" "gff3" "bed"} format))
+(defn tabular? [format] (contains? #{"tsv" "csv"} format))
+
 (defn format-dropdown
   "creates the dropdown to allow users to select their preferred format"
   [loc {:keys [format accepted-formats order-formats]}]
@@ -140,7 +143,7 @@
 
 (defn modal-body
   [loc]
-  (let [data-out @(subscribe [:settings/data-out loc])]
+  (let [{:keys [format] :as data-out} @(subscribe [:settings/data-out loc])]
     [:div.exporttable-body
      [:div.form
       [:div.form-group
@@ -154,8 +157,10 @@
          [format-dropdown loc data-out]]]]]
      [:div.export-options
       [preview-panel loc]
-      [column-headers-panel loc data-out]
-      [rows-panel loc data-out]
+      (when (tabular? format)
+        [column-headers-panel loc data-out])
+      (when-not (bioinf? format)
+        [rows-panel loc data-out])
       [data-package-panel loc data-out]
       [compression-panel loc data-out]]]))
 


### PR DESCRIPTION
Expand export modal functionality to at least match the one of the old im-tables.

Fixes #101

Remember to test integrated in BG before merging.

<img width="610" alt="Screenshot 2022-10-03 at 13 52 22" src="https://user-images.githubusercontent.com/3865590/193582077-a6f877f7-f57c-432d-99eb-765fc62ee482.png">
